### PR TITLE
Adding new option - dynamic heurstic for the wild pass. Enabling this recovers most of the text for apple discussion

### DIFF
--- a/core-options.go
+++ b/core-options.go
@@ -143,6 +143,12 @@ type Options struct {
 
 	// PruneSelector is the CSS selector to select nodes to be pruned before extraction.
 	PruneSelector string
+
+	// Whether to use the dynamic heuristic to extract wild content
+	// if set to true, it will compare the length of the text in all paragraphs
+	// with the length of the text recovered from the original document and if it has
+	// lost more than 25% of the text, it will run the recoverWildText function
+	DynamicHeuristicNeedWildPass bool
 }
 
 // Config is advanced setting to fine tune the extraction result.

--- a/core-options.go
+++ b/core-options.go
@@ -143,12 +143,6 @@ type Options struct {
 
 	// PruneSelector is the CSS selector to select nodes to be pruned before extraction.
 	PruneSelector string
-
-	// Whether to use the dynamic heuristic to extract wild content
-	// if set to true, it will compare the length of the text in all paragraphs
-	// with the length of the text recovered from the original document and if it has
-	// lost more than 25% of the text, it will run the recoverWildText function
-	DynamicHeuristicNeedWildPass bool
 }
 
 // Config is advanced setting to fine tune the extraction result.

--- a/core-options.go
+++ b/core-options.go
@@ -143,6 +143,9 @@ type Options struct {
 
 	// PruneSelector is the CSS selector to select nodes to be pruned before extraction.
 	PruneSelector string
+
+	// Whether to filter out cookie banners with custom discard selector or not.
+	FilterCookieBanners bool
 }
 
 // Config is advanced setting to fine tune the extraction result.

--- a/core-options.go
+++ b/core-options.go
@@ -166,6 +166,11 @@ type Config struct {
 	MinExtractedCommentSize int
 	MinOutputSize           int
 	MinOutputCommentSize    int
+
+	// What is the minimum percentage amount of text in all paragraphs
+	// that should be extracted. If the ratio is bellow this percentage,
+	// recoverWildText will be used to try to recover more text.
+	MinExtractedParagraphPercent float64
 }
 
 // DefaultConfig returns the default configuration value.

--- a/core.go
+++ b/core.go
@@ -124,13 +124,16 @@ func ExtractDocument(doc *html.Node, opts Options) (*ExtractResult, error) {
 	// No backup as this is completely full control of the user.
 	if opts.PruneSelector != "" {
 		cssSelector, err := cascadia.ParseGroup(opts.PruneSelector)
+
 		if err == nil {
-			doc = pruneUnwantedNodes(doc, []selector.Rule{cssSelector.Match})
+			doc = pruneUnwantedNodes(doc, []selector.Rule{cssSelector.Match}, false)
 		}
 	}
 
-	// DDG - custom prune selectors
-	doc = pruneUnwantedNodes(doc, selector.CustomDDGSelectors, false)
+	if opts.FilterCookieBanners {
+		// DDG - custom prune selectors
+		doc = pruneUnwantedNodes(doc, selector.CustomDDGSelectors, false)
+	}
 
 	// Backup document to make sure the original kept untouched
 	doc = dom.Clone(doc, true)

--- a/core.go
+++ b/core.go
@@ -129,6 +129,9 @@ func ExtractDocument(doc *html.Node, opts Options) (*ExtractResult, error) {
 		}
 	}
 
+	// DDG - custom prune selectors
+	doc = pruneUnwantedNodes(doc, selector.CustomDDGSelectors, false)
+
 	// Backup document to make sure the original kept untouched
 	doc = dom.Clone(doc, true)
 	docBackup1 := dom.Clone(doc, true)

--- a/html-processing.go
+++ b/html-processing.go
@@ -23,7 +23,6 @@ package trafilatura
 
 import (
 	"maps"
-	"strings"
 	"unicode/utf8"
 
 	"github.com/go-shiori/dom"
@@ -138,17 +137,6 @@ func pruneHTML(doc *html.Node, opts Options) {
 	}
 }
 
-func hasOTAncestor(n *html.Node) bool {
-	for p := n; p != nil; p = p.Parent {
-		if strings.HasPrefix(dom.ID(p), "ot-") ||
-			strings.HasPrefix(dom.ID(p), "onetrust") ||
-			strings.Contains(dom.ClassName(p), "ot-") {
-			return true
-		}
-	}
-	return false
-}
-
 // pruneUnwantedNodes prune the HTML tree by removing unwanted sections.
 func pruneUnwantedNodes(tree *html.Node, queries []selector.Rule, withBackup ...bool) *html.Node {
 	var oldLen int
@@ -165,11 +153,6 @@ func pruneUnwantedNodes(tree *html.Node, queries []selector.Rule, withBackup ...
 		subElements := selector.QueryAll(tree, query)
 		for i := len(subElements) - 1; i >= 0; i-- {
 			subElement := subElements[i]
-
-			if hasOTAncestor(subElement) {
-				etree.Remove(subElement)
-				continue
-			}
 
 			// Preserve tail text from deletion
 			tail := etree.Tail(subElement)

--- a/html-processing.go
+++ b/html-processing.go
@@ -23,6 +23,7 @@ package trafilatura
 
 import (
 	"maps"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/go-shiori/dom"
@@ -137,6 +138,17 @@ func pruneHTML(doc *html.Node, opts Options) {
 	}
 }
 
+func hasOTAncestor(n *html.Node) bool {
+	for p := n; p != nil; p = p.Parent {
+		if strings.HasPrefix(dom.ID(p), "ot-") ||
+			strings.HasPrefix(dom.ID(p), "onetrust") ||
+			strings.Contains(dom.ClassName(p), "ot-") {
+			return true
+		}
+	}
+	return false
+}
+
 // pruneUnwantedNodes prune the HTML tree by removing unwanted sections.
 func pruneUnwantedNodes(tree *html.Node, queries []selector.Rule, withBackup ...bool) *html.Node {
 	var oldLen int
@@ -153,6 +165,11 @@ func pruneUnwantedNodes(tree *html.Node, queries []selector.Rule, withBackup ...
 		subElements := selector.QueryAll(tree, query)
 		for i := len(subElements) - 1; i >= 0; i-- {
 			subElement := subElements[i]
+
+			if hasOTAncestor(subElement) {
+				etree.Remove(subElement)
+				continue
+			}
 
 			// Preserve tail text from deletion
 			tail := etree.Tail(subElement)

--- a/internal/selector/content-discard-overall.go
+++ b/internal/selector/content-discard-overall.go
@@ -29,6 +29,7 @@ import (
 var OverallDiscardedContent = []Rule{
 	overallDiscardedContentRule1,
 	overallDiscardedContentRule2,
+	discardedLegalRules,
 }
 
 // navigation + footers, news outlets related posts, sharing, jp-post-flair jp-relatedposts
@@ -224,4 +225,58 @@ func overallDiscardedContentRule2(n *html.Node) bool {
 
 	return true
 
+}
+
+// discardedLegalRules filters out cookie-consent banners, privacy footers
+// and similar legal boiler-plate.
+//
+// It returns true when the node (or its attributes) match any of the
+// heuristics; selector.PruneUnwantedSections will then remove the node.
+func discardedLegalRules(n *html.Node) bool {
+	tag := dom.TagName(n)
+	id := dom.ID(n)
+	class := dom.ClassName(n)
+	src := dom.GetAttribute(n, "src")
+	idClass := id + class
+	idClassLower := lower(idClass) // helper already defined in selector utils
+
+	// ------------------------------------------------------------------
+	// 1. Script tags that load cookielaw / consent libraries
+	// ------------------------------------------------------------------
+	if tag == "script" && contains(lower(src), "cookielaw") {
+		return true
+	}
+
+	// ------------------------------------------------------------------
+	// 2. Plain footer element (very often just legal text)
+	// ------------------------------------------------------------------
+	if tag == "footer" {
+		return true
+	}
+
+	// ------------------------------------------------------------------
+	// 3. Known cookie / consent SDK containers
+	// ------------------------------------------------------------------
+	if id == "onetrust-consent-sdk" || startsWith(id, "ot-sdk") {
+		return true
+	}
+
+	// ------------------------------------------------------------------
+	// 4. Heuristic keywords in id / class
+	// ------------------------------------------------------------------
+	switch {
+	case contains(idClassLower, "cookie"),
+		contains(idClassLower, "consent"),
+		contains(idClassLower, "privacy"),
+		contains(idClassLower, "gdpr"),
+		contains(idClassLower, "legal"),
+		contains(idClassLower, "optanon"),
+		contains(idClassLower, "cmp"), // IAB / TCF CMPs
+		contains(idClassLower, "truste"),
+		contains(idClassLower, "evidon"),
+		contains(idClassLower, "onetrust"):
+		return true
+	}
+
+	return false
 }

--- a/internal/selector/content-discard-overall.go
+++ b/internal/selector/content-discard-overall.go
@@ -22,6 +22,8 @@
 package selector
 
 import (
+	"strings"
+
 	"github.com/go-shiori/dom"
 	"golang.org/x/net/html"
 )
@@ -258,6 +260,10 @@ func discardedLegalRules(n *html.Node) bool {
 	// 3. Known cookie / consent SDK containers
 	// ------------------------------------------------------------------
 	if id == "onetrust-consent-sdk" || startsWith(id, "ot-sdk") {
+		return true
+	}
+	// inner OneTrust containers – catch them even if outer div was stripped
+	if strings.HasPrefix(id, "ot-") || strings.Contains(class, "ot-") {
 		return true
 	}
 

--- a/internal/selector/content-discard-overall.go
+++ b/internal/selector/content-discard-overall.go
@@ -31,7 +31,7 @@ import (
 var OverallDiscardedContent = []Rule{
 	overallDiscardedContentRule1,
 	overallDiscardedContentRule2,
-	discardedLegalRules,
+	discardedLegalRule,
 }
 
 // navigation + footers, news outlets related posts, sharing, jp-post-flair jp-relatedposts
@@ -229,12 +229,12 @@ func overallDiscardedContentRule2(n *html.Node) bool {
 
 }
 
-// discardedLegalRules filters out cookie-consent banners, privacy footers
+// discardedLegalRule filters out cookie-consent banners, privacy footers
 // and similar legal boiler-plate.
 //
 // It returns true when the node (or its attributes) match any of the
 // heuristics; selector.PruneUnwantedSections will then remove the node.
-func discardedLegalRules(n *html.Node) bool {
+func discardedLegalRule(n *html.Node) bool {
 	tag := dom.TagName(n)
 	id := dom.ID(n)
 	class := dom.ClassName(n)

--- a/internal/selector/content-discard-overall.go
+++ b/internal/selector/content-discard-overall.go
@@ -31,7 +31,7 @@ import (
 var OverallDiscardedContent = []Rule{
 	overallDiscardedContentRule1,
 	overallDiscardedContentRule2,
-	discardedLegalRule,
+	DiscardedLegalRule,
 }
 
 // navigation + footers, news outlets related posts, sharing, jp-post-flair jp-relatedposts
@@ -229,12 +229,12 @@ func overallDiscardedContentRule2(n *html.Node) bool {
 
 }
 
-// discardedLegalRule filters out cookie-consent banners, privacy footers
+// DiscardedLegalRule filters out cookie-consent banners, privacy footers
 // and similar legal boiler-plate.
 //
 // It returns true when the node (or its attributes) match any of the
 // heuristics; selector.PruneUnwantedSections will then remove the node.
-func discardedLegalRule(n *html.Node) bool {
+func DiscardedLegalRule(n *html.Node) bool {
 	tag := dom.TagName(n)
 	id := dom.ID(n)
 	class := dom.ClassName(n)

--- a/internal/selector/duckduckgo.go
+++ b/internal/selector/duckduckgo.go
@@ -1,0 +1,5 @@
+package selector
+
+var CustomDDGSelectors = []Rule{
+	DiscardedLegalRule,
+}

--- a/main-extractor.go
+++ b/main-extractor.go
@@ -620,10 +620,6 @@ func recoverWildText(doc, resultBody *html.Node, potentialTags map[string]struct
 	selectors := strings.Join(selectorList, ", ")
 	for _, element := range dom.QuerySelectorAll(searchDoc, selectors) {
 
-		if hasOTAncestor(element) {
-			continue // ignore everything that lives under ot-/onetrust
-		}
-
 		processedElement := handleTextElem(element, potentialTags, cache, opts)
 		if processedElement != nil {
 			processedElems = append(processedElems, processedElement)

--- a/main-extractor.go
+++ b/main-extractor.go
@@ -614,6 +614,11 @@ func recoverWildText(doc, resultBody *html.Node, potentialTags map[string]struct
 	var processedElems []*html.Node
 	selectors := strings.Join(selectorList, ", ")
 	for _, element := range dom.QuerySelectorAll(searchDoc, selectors) {
+
+		if hasOTAncestor(element) {
+			continue // ignore everything that lives under ot-/onetrust
+		}
+
 		processedElement := handleTextElem(element, potentialTags, cache, opts)
 		if processedElement != nil {
 			processedElems = append(processedElems, processedElement)
@@ -814,6 +819,7 @@ func extractContent(doc *html.Node, cache *lru.Cache, opts Options) (*html.Node,
 	// Filter output
 	etree.StripElements(resultBody, false, "done")
 	etree.StripTags(resultBody, "div")
+
 	return resultBody, tmpText
 }
 

--- a/main-extractor.go
+++ b/main-extractor.go
@@ -3,7 +3,6 @@ package trafilatura
 import (
 	"maps"
 	"strings"
-	"unicode"
 	"unicode/utf8"
 
 	"github.com/go-shiori/dom"
@@ -14,13 +13,13 @@ import (
 )
 
 func safeAppend(parent, child *html.Node) {
-	if last := parent.LastChild; last != nil {
-		lastTxt := etree.IterText(last, "")
-		firstTxt := etree.IterText(child, "")
+	if last := parent.LastChild; last != nil && child != nil {
+		lastTail := strings.TrimRight(etree.Tail(last), " ")
+		firstText := strings.TrimLeft(etree.Text(child), " ")
 
-		if lastTxt != "" && firstTxt != "" {
-			r, _ := utf8.DecodeLastRuneInString(lastTxt)
-			if !unicode.IsSpace(r) { // ← no whitespace at end
+		// Check if last ends with non-whitespace AND child starts with non-whitespace
+		if lastTail != "" && firstText != "" {
+			if !strings.HasSuffix(lastTail, " ") && !strings.HasPrefix(firstText, " ") {
 				etree.SetTail(last, etree.Tail(last)+" ")
 			}
 		}

--- a/trafilatura_test.go
+++ b/trafilatura_test.go
@@ -423,6 +423,31 @@ func Test_Formatting(t *testing.T) {
 	assert.Contains(t, fnHtml(result), `The <code>in</code> operator is used to check data structures for membership in Python.`)
 	assert.Contains(t, fnHtml(result), `It returns a Boolean (either <code>True</code> or <code>False</code>) and can be used as follows:`)
 
+	// Spans without spaces
+	r = strings.NewReader(`
+		<html><body>
+			<article data-testid="content-post" id="asset:d51deea4-5d25-483a-8467-ad25292104d7" class="ssrcss-1b1nywt-ContentPost e6wdqbx1">
+			<header class="ssrcss-1p40248-Header e14e9ror5">
+				<span class="ssrcss-1de7kuz-HeadingContainer e14e9ror1">
+					<h3 type="normal" class="ssrcss-ad2rmd-Heading e10rt3ze0">
+						<span role="text" class="ssrcss-189b1h2-HeadlineWrap e14e9ror2">
+							<span>Goodbye!</span><span class="ssrcss-rcvhal-ServerSideTime e14e9ror0">
+							<span data-testid="timestamp" class="ssrcss-umer6k-Timestamp ekpio9q4">
+								<span data-testid="accessible-timestamp" class="visually-hidden ssrcss-1f39n02-VisuallyHidden e16en2lz0">published at 23:05 British Summer Time 4 June</span>
+								<div class="ssrcss-1kjj6jl-Wrapper ekpio9q3"><span aria-hidden="true" class="ssrcss-crgz56-Time ekpio9q2">23:05 BST 4 June</span></div>
+							</span>
+						</span>
+					</h3>
+				</span>
+			</header>
+		</article>
+	</body></html>`)
+	result, _ = Extract(r, zeroOpts)
+	normalized := func(s string) string {
+		return strings.Join(strings.Fields(s), " ")
+	}
+	assert.Contains(t, normalized(fnHtml(result)), `Goodbye! published at 23:05 British Summer Time 4 June`)
+
 	// Double <p> elems
 	r = strings.NewReader("<html><body><p>AAA, <p>BBB</p>, CCC.</p></body></html>")
 	result, _ = Extract(r, Options{IncludeLinks: true, Config: zeroConfig})


### PR DESCRIPTION
1/ This apple page: https://discussions.apple.com/thread/252649614?sortBy=rank contains a lot of text in answers.

The paragraphTxt is ~7k characters long, but this is only used as heuristic at the beginning to decide whether additional divs should be used or not.

The recoverWildText method is only called when there's no enough text (the length of the text is < required min text) so it never returns the potential for this page.

This is a generic problem as we pass static config to trafilatura
```
...
MinExtractedSize:        250,
...
```

and we don't know how much text we can actually extract ahead of time.

This trafilatura PR tackles that by adding new option that does what we want for this and similar pages.

For backwards compatibility and to have all the existing trafilatura tests green, the desired behaviour is changed based on a option flag.  - to compare the paragraph text length with the tmp text length and see if we've lost too much (>25%) as a decision whether to run the recoverWildText or not.

 https://github.com/pkrayzel-duckduckgo/go-trafilatura/pull/1/files#diff-7424195e2ad7f5b675062309b9a59f5071909a5ac31154c034383851230885ccR792

2/ RottenTomatoes page was missing lots of text. Mainly from special tags `rt-text` etc.

3/ With the above modifications, one trust cookie consent was returned (affected pages such as cnbc.com etc).

Now it is being filtered based on the known tags and prefixes.