### PR TITLE
More advanced cases improving DDG recall - term separation, video modals filtering, ...

### DIFF
--- a/baseline.go
+++ b/baseline.go
@@ -38,7 +38,7 @@ func baseline(doc *html.Node) (*html.Node, string) {
 	// Scrape JSON+LD for article body
 	for _, script := range dom.QuerySelectorAll(doc, `script[type="application/ld+json"]`) {
 		// Get the json text inside the script
-		jsonLdText := dom.TextContent(script)
+		jsonLdText := etree.IterTextWithSpacing(script)
 		jsonLdText = strings.TrimSpace(jsonLdText)
 		jsonLdText = html.UnescapeString(jsonLdText)
 		if jsonLdText == "" {
@@ -65,7 +65,7 @@ func baseline(doc *html.Node) (*html.Node, string) {
 						if strings.Contains(v, "<p>") {
 							tmp := dom.CreateElement("div")
 							dom.SetInnerHTML(tmp, v)
-							articleBody = trim(dom.TextContent(tmp))
+							articleBody = trim(etree.IterTextWithSpacing(tmp))
 						} else {
 							articleBody = v
 						}
@@ -104,7 +104,7 @@ func baseline(doc *html.Node) (*html.Node, string) {
 	// Scrape from article tag
 	articleElement := dom.QuerySelector(doc, "article")
 	if articleElement != nil {
-		articleText := trim(dom.TextContent(articleElement))
+		articleText := trim(etree.IterTextWithSpacing(articleElement))
 		if utf8.RuneCountInString(articleText) > 100 {
 			p := etree.SubElement(postBody, "p")
 			etree.SetText(p, articleText)
@@ -120,7 +120,7 @@ func baseline(doc *html.Node) (*html.Node, string) {
 	// Scrape from text paragraphs
 	results := make(map[string]struct{})
 	for _, element := range etree.Iter(doc, "blockquote", "pre", "q", "code", "p") {
-		entry := trim(dom.TextContent(element))
+		entry := trim(etree.IterTextWithSpacing(element))
 		if _, exist := results[entry]; !exist {
 			p := etree.SubElement(postBody, "p")
 			etree.SetText(p, entry)
@@ -145,7 +145,7 @@ func baseline(doc *html.Node) (*html.Node, string) {
 	}
 
 	// New fallback
-	text := trim(dom.TextContent(doc))
+	text := trim(etree.IterTextWithSpacing(doc))
 	elem := etree.SubElement(postBody, "p")
 	etree.SetText(elem, text)
 	return postBody, text

--- a/baseline.go
+++ b/baseline.go
@@ -12,6 +12,8 @@ import (
 
 var basicCleaningSelector = strings.Join([]string{
 	`aside`,
+	"nav",
+	"[role='navigation']",
 	`footer`,
 	`div[id*="footer"]`,
 	`div[class*="footer"]`,

--- a/core-options.go
+++ b/core-options.go
@@ -146,6 +146,9 @@ type Options struct {
 
 	// Whether to filter out cookie banners with custom discard selector or not.
 	FilterCookieBanners bool
+
+	// Whether to filter out video modals with custom discard selector or not.
+	FilterVideoModals bool
 }
 
 // Config is advanced setting to fine tune the extraction result.

--- a/core-options.go
+++ b/core-options.go
@@ -149,6 +149,12 @@ type Options struct {
 
 	// Whether to filter out audio/video/media modals with custom discard selector or not.
 	FilterMediaModals bool
+
+	// Whether to include lists in the wild text recovery or not.
+	IncludeLists bool
+
+	// Whether to include span elements in the wild text recovery or not.
+	IncludeSpans bool
 }
 
 // Config is advanced setting to fine tune the extraction result.

--- a/core-options.go
+++ b/core-options.go
@@ -147,8 +147,8 @@ type Options struct {
 	// Whether to filter out cookie banners with custom discard selector or not.
 	FilterCookieBanners bool
 
-	// Whether to filter out video modals with custom discard selector or not.
-	FilterVideoModals bool
+	// Whether to filter out audio/video/media modals with custom discard selector or not.
+	FilterMediaModals bool
 }
 
 // Config is advanced setting to fine tune the extraction result.

--- a/core-options.go
+++ b/core-options.go
@@ -177,6 +177,28 @@ type Config struct {
 	// that should be extracted. If the ratio is bellow this percentage,
 	// recoverWildText will be used to try to recover more text.
 	MinExtractedParagraphPercent float64
+
+	// What is the minimum word count of a sentence that should be considered quality.
+	MinWordsPerSentence int
+
+	// What is the minimum number of sentences that should be extracted to consider the
+	// document as valid. If the number of sentences is bellow this number,
+	// the fallback mechanism will be used to try to recover more text.
+	MinNarrativeSentences int
+
+	// Structured content config
+
+	// What is the minimum number of words in a list item that should be considered quality content.
+	// This is used for dictionary pages where the list items are often very short and not sentences.
+	MinWordsPerStructuredBlock int
+
+	// What is the minimum number of structured blocks that should be extracted to consider the
+	// document as valid. If the number of structured blocks is bellow this number,
+	// the fallback mechanism will be used to try to recover more text.
+	MinStructuredBlocks int
+
+	// Threshold for minimum number of words to be considered dictionary/structured content
+	MinTotalWords int
 }
 
 // DefaultConfig returns the default configuration value.

--- a/core-options.go
+++ b/core-options.go
@@ -25,6 +25,7 @@ import (
 	nurl "net/url"
 
 	"github.com/markusmobius/go-htmldate"
+	"github.com/rs/zerolog"
 	"golang.org/x/net/html"
 )
 
@@ -155,6 +156,11 @@ type Options struct {
 
 	// Whether to include span elements in the wild text recovery or not.
 	IncludeSpans bool
+
+	// What phrases to debug throughout the extraction process.
+	DebugTargetPhrases []string
+	// DebugLogger is the logger used to log debug messages.
+	DebugLogger zerolog.Logger
 }
 
 // Config is advanced setting to fine tune the extraction result.

--- a/core.go
+++ b/core.go
@@ -167,6 +167,7 @@ func ExtractDocument(doc *html.Node, opts Options) (*ExtractResult, error) {
 	// Rescue: try to use original/dirty tree
 	lenText := utf8.RuneCountInString(tmpBodyText)
 	if lenText < opts.Config.MinExtractedSize && opts.Focus != FavorPrecision {
+
 		postBody, tmpBodyText = baseline(docBackup2)
 	}
 

--- a/core.go
+++ b/core.go
@@ -169,9 +169,23 @@ func ExtractDocument(doc *html.Node, opts Options) (*ExtractResult, error) {
 
 	// Rescue: try to use original/dirty tree
 	lenText := utf8.RuneCountInString(tmpBodyText)
-	if lenText < opts.Config.MinExtractedSize && opts.Focus != FavorPrecision {
 
+	if lenText < opts.Config.MinExtractedSize && opts.Focus != FavorPrecision {
 		postBody, tmpBodyText = baseline(docBackup2)
+	}
+
+	originalIsLowQuality := isLowQualityContent(postBody, opts)
+
+	if originalIsLowQuality {
+		rescuedPostBody, rescuedTmpBodyText := baseline(docBackup2)
+
+		rescuedIsLowQuality := isLowQualityContent(rescuedPostBody, opts)
+
+		if len(rescuedTmpBodyText) > len(tmpBodyText) || !rescuedIsLowQuality {
+
+			postBody = rescuedPostBody
+			tmpBodyText = rescuedTmpBodyText
+		}
 	}
 
 	// Tree size sanity check

--- a/core.go
+++ b/core.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	nurl "net/url"
 	"os"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/andybalholm/cascadia"
@@ -120,6 +121,8 @@ func ExtractDocument(doc *html.Node, opts Options) (*ExtractResult, error) {
 		}
 	}
 
+	tracePhrase("html-parsing", doc, opts)
+
 	// Prune using selectors that user specified.
 	// No backup as this is completely full control of the user.
 	if opts.PruneSelector != "" {
@@ -132,10 +135,12 @@ func ExtractDocument(doc *html.Node, opts Options) (*ExtractResult, error) {
 
 	if opts.FilterCookieBanners {
 		doc = pruneUnwantedNodes(doc, []selector.Rule{selector.DiscardedLegalRule}, false)
+		tracePhrase("filter-cookie-banners", doc, opts)
 	}
 
 	if opts.FilterMediaModals {
 		doc = pruneUnwantedNodes(doc, []selector.Rule{selector.DiscardedMediaUIRule}, false)
+		tracePhrase("filter-media-modals", doc, opts)
 	}
 
 	// Backup document to make sure the original kept untouched
@@ -162,9 +167,14 @@ func ExtractDocument(doc *html.Node, opts Options) (*ExtractResult, error) {
 	// Extract content
 	postBody, tmpBodyText := extractContent(doc, cache, opts)
 
+	tracePhrase("post-extract-content", postBody, opts)
+
+	// TBD - check whether sentence X was present in the full doc after content extraction (without fallbacks here)
+
 	// Use fallback if necessary
 	if opts.EnableFallback {
 		postBody, tmpBodyText = compareExternalExtraction(docBackup1, postBody, opts)
+		tracePhrase("post-external-extraction", postBody, opts)
 	}
 
 	// Rescue: try to use original/dirty tree
@@ -172,11 +182,13 @@ func ExtractDocument(doc *html.Node, opts Options) (*ExtractResult, error) {
 
 	if lenText < opts.Config.MinExtractedSize && opts.Focus != FavorPrecision {
 		postBody, tmpBodyText = baseline(docBackup2)
+		tracePhrase("post-rescue-from-original-tree", postBody, opts)
 	}
 
 	originalIsLowQuality := isLowQualityContent(postBody, opts)
 
 	if originalIsLowQuality {
+
 		rescuedPostBody, rescuedTmpBodyText := baseline(docBackup2)
 
 		rescuedIsLowQuality := isLowQualityContent(rescuedPostBody, opts)
@@ -185,6 +197,8 @@ func ExtractDocument(doc *html.Node, opts Options) (*ExtractResult, error) {
 
 			postBody = rescuedPostBody
 			tmpBodyText = rescuedTmpBodyText
+
+			tracePhrase("post-rescue-from-original-tree-low-quality", rescuedPostBody, opts)
 		}
 	}
 
@@ -240,4 +254,21 @@ func ExtractDocument(doc *html.Node, opts Options) (*ExtractResult, error) {
 		CommentsText: tmpComments,
 		Metadata:     metadata,
 	}, nil
+}
+
+func tracePhrase(stage string, doc *html.Node, opts Options) {
+	if len(opts.DebugTargetPhrases) == 0 {
+		return
+	}
+
+	text := etree.IterTextWithSpacing(doc)
+	for _, phrase := range opts.DebugTargetPhrases {
+		found := strings.Contains(text, phrase)
+		opts.DebugLogger.Info().
+			Str("stage", stage).
+			Str("phrase", phrase).
+			Bool("present", found).
+			Int("length", len(text)).
+			Msg("Phrase check")
+	}
 }

--- a/core.go
+++ b/core.go
@@ -134,8 +134,8 @@ func ExtractDocument(doc *html.Node, opts Options) (*ExtractResult, error) {
 		doc = pruneUnwantedNodes(doc, []selector.Rule{selector.DiscardedLegalRule}, false)
 	}
 
-	if opts.FilterVideoModals {
-		doc = pruneUnwantedNodes(doc, []selector.Rule{selector.DiscardedVideoUIRule}, false)
+	if opts.FilterMediaModals {
+		doc = pruneUnwantedNodes(doc, []selector.Rule{selector.DiscardedMediaUIRule}, false)
 	}
 
 	// Backup document to make sure the original kept untouched

--- a/core.go
+++ b/core.go
@@ -131,8 +131,11 @@ func ExtractDocument(doc *html.Node, opts Options) (*ExtractResult, error) {
 	}
 
 	if opts.FilterCookieBanners {
-		// DDG - custom prune selectors
-		doc = pruneUnwantedNodes(doc, selector.CustomDDGSelectors, false)
+		doc = pruneUnwantedNodes(doc, []selector.Rule{selector.DiscardedLegalRule}, false)
+	}
+
+	if opts.FilterVideoModals {
+		doc = pruneUnwantedNodes(doc, []selector.Rule{selector.DiscardedVideoUIRule}, false)
 	}
 
 	// Backup document to make sure the original kept untouched

--- a/html-processing.go
+++ b/html-processing.go
@@ -447,6 +447,15 @@ func postCleaning(doc *html.Node) {
 	}
 }
 
+func isWhitelisted(elem *html.Node) bool {
+	for n := elem; n != nil; n = n.Parent {
+		if dom.GetAttribute(n, "data-whitelist") == "true" {
+			return true
+		}
+	}
+	return false
+}
+
 // deleteByLinkDensity determines the link density of elements with respect to
 // their length, and remove the elements identified as boilerplate.
 func deleteByLinkDensity(subTree *html.Node, opts Options, backtracking bool, tagNames ...string) {
@@ -459,7 +468,19 @@ func deleteByLinkDensity(subTree *html.Node, opts Options, backtracking bool, ta
 		nChildLimit = 1
 	}
 
+	// first pass is to mark whitelisted elements
 	for _, elem := range etree.Iter(subTree, tagNames...) {
+		if selector.IsWhitelistedCategoryList(elem) {
+			dom.SetAttribute(elem, "data-whitelist", "true")
+		}
+	}
+
+	for _, elem := range etree.Iter(subTree, tagNames...) {
+		// Skip whitelisted high-link-density blocks - checking their parents
+		if isWhitelisted(elem) {
+			continue
+		}
+
 		nonEmptyLinks, isHighDensity := linkDensityTest(elem, opts)
 
 		if isHighDensity {

--- a/internal/selector/content-discard-overall.go
+++ b/internal/selector/content-discard-overall.go
@@ -251,10 +251,15 @@ func DiscardedLegalRule(n *html.Node) bool {
 	}
 
 	// ------------------------------------------------------------------
-	// 2. Plain footer element (very often just legal text)
+	// 2. Plain footer element (check for actual content first)
 	// ------------------------------------------------------------------
 	if tag == "footer" {
-		return true
+		txt := strings.ToLower(dom.TextContent(n))
+		if strings.Contains(txt, "cookie") || strings.Contains(txt, "consent") || strings.Contains(txt, "privacy") {
+			return true
+		}
+		// Otherwise, keep eg. wikipedia footers etc.
+		return false
 	}
 
 	// ------------------------------------------------------------------
@@ -264,7 +269,7 @@ func DiscardedLegalRule(n *html.Node) bool {
 		return true
 	}
 	// inner OneTrust containers – catch them even if outer div was stripped
-	if strings.HasPrefix(id, "ot-") || strings.Contains(class, "ot-") {
+	if hasOTClass(n) {
 		return true
 	}
 
@@ -285,6 +290,15 @@ func DiscardedLegalRule(n *html.Node) bool {
 		return true
 	}
 
+	return false
+}
+
+func hasOTClass(n *html.Node) bool {
+	for _, c := range strings.Fields(dom.ClassName(n)) {
+		if strings.HasPrefix(c, "ot-") {
+			return true
+		}
+	}
 	return false
 }
 

--- a/internal/selector/content-discard-overall.go
+++ b/internal/selector/content-discard-overall.go
@@ -32,6 +32,7 @@ var OverallDiscardedContent = []Rule{
 	overallDiscardedContentRule1,
 	overallDiscardedContentRule2,
 	DiscardedLegalRule,
+	DiscardedVideoUIRule,
 }
 
 // navigation + footers, news outlets related posts, sharing, jp-post-flair jp-relatedposts
@@ -281,6 +282,72 @@ func DiscardedLegalRule(n *html.Node) bool {
 		contains(idClassLower, "truste"),
 		contains(idClassLower, "evidon"),
 		contains(idClassLower, "onetrust"):
+		return true
+	}
+
+	return false
+}
+
+// DiscardedVideoUIRule filters out video player containers and modal/dialog
+// boilerplate that often pollutes fallback content extraction.
+//
+// It returns true when the node (or its attributes) match any of the
+// heuristics; selector.PruneUnwantedSections will then remove the node.
+func DiscardedVideoUIRule(n *html.Node) bool {
+	tag := dom.TagName(n)
+	id := dom.ID(n)
+	class := dom.ClassName(n)
+	idClass := id + class
+	idClassLower := lower(idClass) // helper already defined in selector utils
+
+	// ------------------------------------------------------------------
+	// 1. Tags explicitly related to video elements
+	// ------------------------------------------------------------------
+	if tag == "video" || tag == "source" {
+		return true
+	}
+
+	// <p class="vjs-no-js"> fallback
+	if tag == "p" && contains(class, "vjs-no-js") {
+		return true
+	}
+
+	// ------------------------------------------------------------------
+	// 2. Common video player containers
+	// ------------------------------------------------------------------
+	switch {
+	case contains(idClassLower, "video-player"),
+		contains(idClassLower, "vjs-"),
+		contains(idClassLower, "videojs"),
+		contains(idClassLower, "html5-video"),
+		contains(idClassLower, "mux-player"),
+		contains(idClassLower, "plyr"): // other common player lib
+		return true
+	}
+
+	// ------------------------------------------------------------------
+	// 3. Modal or dialog boilerplate often embedded in video overlays
+	// ------------------------------------------------------------------
+	switch {
+	case contains(idClassLower, "modal"),
+		contains(idClassLower, "dialog"),
+		contains(idClassLower, "lightbox"),
+		contains(idClassLower, "popup"),
+		contains(idClassLower, "overlay"):
+		return true
+	}
+
+	// ------------------------------------------------------------------
+	// 4. Video-specific script embeds (optional)
+	// ------------------------------------------------------------------
+	src := dom.GetAttribute(n, "src")
+	srcLower := lower(src)
+
+	if tag == "script" && (contains(srcLower, "videojs") ||
+		contains(srcLower, "vjs") ||
+		contains(srcLower, "mux") ||
+		contains(srcLower, "brightcove") ||
+		contains(srcLower, "jwplayer")) {
 		return true
 	}
 

--- a/internal/selector/content-discard-overall.go
+++ b/internal/selector/content-discard-overall.go
@@ -32,7 +32,7 @@ var OverallDiscardedContent = []Rule{
 	overallDiscardedContentRule1,
 	overallDiscardedContentRule2,
 	DiscardedLegalRule,
-	DiscardedVideoUIRule,
+	DiscardedMediaUIRule,
 }
 
 // navigation + footers, news outlets related posts, sharing, jp-post-flair jp-relatedposts
@@ -288,68 +288,95 @@ func DiscardedLegalRule(n *html.Node) bool {
 	return false
 }
 
-// DiscardedVideoUIRule filters out video player containers and modal/dialog
-// boilerplate that often pollutes fallback content extraction.
-//
-// It returns true when the node (or its attributes) match any of the
-// heuristics; selector.PruneUnwantedSections will then remove the node.
-func DiscardedVideoUIRule(n *html.Node) bool {
+func hasClass(n *html.Node, class string) bool {
+	for _, c := range strings.Fields(dom.ClassName(n)) {
+		if c == class {
+			return true
+		}
+	}
+	return false
+}
+
+func DiscardedMediaUIRule(n *html.Node) bool {
 	tag := dom.TagName(n)
 	id := dom.ID(n)
 	class := dom.ClassName(n)
-	idClass := id + class
-	idClassLower := lower(idClass) // helper already defined in selector utils
+	idLower := lower(id)
+	classLower := lower(class)
 
-	// ------------------------------------------------------------------
-	// 1. Tags explicitly related to video elements
-	// ------------------------------------------------------------------
-	if tag == "video" || tag == "source" {
+	// Only discard source if it's clearly audio/video
+	if tag == "source" {
+		src := dom.GetAttribute(n, "src")
+		srcLower := lower(src)
+		if strings.HasSuffix(srcLower, ".mp3") || strings.HasSuffix(srcLower, ".ogg") ||
+			strings.HasSuffix(srcLower, ".mp4") || strings.Contains(srcLower, "audio") || strings.Contains(srcLower, "video") {
+			return true
+		}
+		return false // keep image/picture source elements
+	}
+
+	// Explicit tags
+	if tag == "video" || tag == "audio" {
 		return true
 	}
 
-	// <p class="vjs-no-js"> fallback
-	if tag == "p" && contains(class, "vjs-no-js") {
+	if tag == "div" {
+		role := lower(dom.GetAttribute(n, "role"))
+		aria := lower(dom.GetAttribute(n, "aria-modal"))
+		if role == "dialog" || aria == "true" {
+			return true
+		}
+
+		if hasClass(n, "modal__content") || hasClass(n, "modal__container") || hasClass(n, "dialog-content") {
+			return true
+		}
+	}
+
+	// Fallbacks for known library classes (but avoid generic ones like "overlay")
+	if tag == "div" || tag == "span" || tag == "button" {
+		switch {
+		case hasClass(n, "video-player"),
+			hasClass(n, "audio-player"),
+			hasClass(n, "audioplayer"),
+			hasClass(n, "vjs-no-js"),
+			hasClass(n, "videojs"),
+			hasClass(n, "html5-video"),
+			hasClass(n, "html5-audio"),
+			hasClass(n, "plyr"),
+			hasClass(n, "mux-player"),
+			hasClass(n, "c_aud"),
+			hasClass(n, "daud"),
+			hasClass(n, "i-volume-up"),
+			hasClass(n, "listen-button"),
+			hasClass(n, "player-wrapper"):
+			return true
+		}
+	}
+
+	// Avoid matching generic classes like "overlay", "modal" unless they're clearly part of a media container
+	if strings.Contains(idLower+classLower, "modal") && isLikelyMediaOverlay(n) {
 		return true
 	}
 
-	// ------------------------------------------------------------------
-	// 2. Common video player containers
-	// ------------------------------------------------------------------
-	switch {
-	case contains(idClassLower, "video-player"),
-		contains(idClassLower, "vjs-"),
-		contains(idClassLower, "videojs"),
-		contains(idClassLower, "html5-video"),
-		contains(idClassLower, "mux-player"),
-		contains(idClassLower, "plyr"): // other common player lib
-		return true
+	// Specific scripts
+	if tag == "script" {
+		src := lower(dom.GetAttribute(n, "src"))
+		if strings.Contains(src, "videojs") || strings.Contains(src, "jwplayer") || strings.Contains(src, "soundcloud") {
+			return true
+		}
 	}
 
-	// ------------------------------------------------------------------
-	// 3. Modal or dialog boilerplate often embedded in video overlays
-	// ------------------------------------------------------------------
-	switch {
-	case contains(idClassLower, "modal"),
-		contains(idClassLower, "dialog"),
-		contains(idClassLower, "lightbox"),
-		contains(idClassLower, "popup"),
-		contains(idClassLower, "overlay"):
-		return true
+	return false
+}
+
+func isLikelyMediaOverlay(n *html.Node) bool {
+	// Look upward for any <video>/<audio> ancestor within 3 hops
+	count := 0
+	for parent := n.Parent; parent != nil && count < 3; parent = parent.Parent {
+		if tag := dom.TagName(parent); tag == "video" || tag == "audio" {
+			return true
+		}
+		count++
 	}
-
-	// ------------------------------------------------------------------
-	// 4. Video-specific script embeds (optional)
-	// ------------------------------------------------------------------
-	src := dom.GetAttribute(n, "src")
-	srcLower := lower(src)
-
-	if tag == "script" && (contains(srcLower, "videojs") ||
-		contains(srcLower, "vjs") ||
-		contains(srcLower, "mux") ||
-		contains(srcLower, "brightcove") ||
-		contains(srcLower, "jwplayer")) {
-		return true
-	}
-
 	return false
 }

--- a/internal/selector/content-discard-overall.go
+++ b/internal/selector/content-discard-overall.go
@@ -53,7 +53,7 @@ var OverallDiscardedContent = []Rule{
 // contains(@id|@class, "cookie") or
 // contains(@id|@class, "tags") or contains(@class, "tag-list") or
 // contains(@id|@class, "sidebar") or
-// contains(@id|@class, "banner") or contains(@class, "bar") or
+// contains(@id|@class, "site-banner") or contains(@class, "bar") or
 // contains(@class, "meta") or contains(@id, "menu") or contains(@class, "menu") or
 // contains(translate(@id, "N", "n"), "nav") or contains(translate(@role, "N", "n"), "nav")
 // or starts-with(@class, "nav") or contains(@class, "avigation") or
@@ -120,7 +120,7 @@ func overallDiscardedContentRule1(n *html.Node) bool {
 		contains(idClass, "tags"),
 		contains(class, "tag-list"),
 		contains(idClass, "sidebar"),
-		contains(idClass, "banner"),
+		contains(idClass, "site-banner"),
 		contains(class, "bar"),
 		contains(class, "meta"),
 		contains(id, "menu"),

--- a/internal/selector/content.go
+++ b/internal/selector/content.go
@@ -33,6 +33,7 @@ var Content = []Rule{
 	contentRule4,
 	contentRule5,
 	contentRuleBBCSummary,
+	contentRuleWikipediaCategory,
 }
 
 // `.//*[self::article or self::div or self::main or self::section][
@@ -239,4 +240,20 @@ func contentRuleBBCSummary(n *html.Node) bool {
 	dataComponent := dom.GetAttribute(n, "data-component")
 
 	return tag == "section" && dataComponent == "summary-block"
+}
+
+func contentRuleWikipediaCategory(n *html.Node) bool {
+	id := dom.ID(n)
+	class := dom.ClassName(n)
+	tag := dom.TagName(n)
+
+	if tag != "div" {
+		return false
+	}
+
+	if id == "mw-pages" || class == "mw-category-group" || class == "mw-category" {
+		return true
+	}
+
+	return false
 }

--- a/internal/selector/content.go
+++ b/internal/selector/content.go
@@ -32,6 +32,7 @@ var Content = []Rule{
 	contentRule3,
 	contentRule4,
 	contentRule5,
+	contentRuleBBCSummary,
 }
 
 // `.//*[self::article or self::div or self::main or self::section][
@@ -231,4 +232,11 @@ func contentRule5(n *html.Node) bool {
 	}
 
 	return true
+}
+
+func contentRuleBBCSummary(n *html.Node) bool {
+	tag := dom.TagName(n)
+	dataComponent := dom.GetAttribute(n, "data-component")
+
+	return tag == "section" && dataComponent == "summary-block"
 }

--- a/internal/selector/duckduckgo.go
+++ b/internal/selector/duckduckgo.go
@@ -1,5 +1,0 @@
-package selector
-
-var CustomDDGSelectors = []Rule{
-	DiscardedLegalRule,
-}

--- a/internal/selector/link_density.go
+++ b/internal/selector/link_density.go
@@ -1,0 +1,17 @@
+package selector
+
+import (
+	"strings"
+
+	"github.com/go-shiori/dom"
+	"golang.org/x/net/html"
+)
+
+func IsWhitelistedCategoryList(n *html.Node) bool {
+	class := dom.ClassName(n)
+	id := dom.ID(n)
+	return strings.Contains(class, "mw-category") ||
+		strings.Contains(id, "mw-pages") ||
+		strings.Contains(class, "mw-category-group") ||
+		strings.Contains(id, "mw-subcategories")
+}

--- a/main-extractor.go
+++ b/main-extractor.go
@@ -834,7 +834,6 @@ func extractContent(doc *html.Node, cache *lru.Cache, opts Options) (*html.Node,
 		// we want to throw away the result body in the case we're recovering wild
 		// text because it's been too short so far, but we haven't missed too much paragraphs
 		if missingRatio < float64(opts.Config.MinExtractedParagraphPercent) {
-			log.Println("We haven't missed too much throwing away the results body")
 			resultBody = dom.CreateElement("body")
 		}
 		recoverWildText(backupDoc, resultBody, potentialTags, cache, opts)

--- a/main-extractor.go
+++ b/main-extractor.go
@@ -3,6 +3,7 @@ package trafilatura
 import (
 	"maps"
 	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/go-shiori/dom"
@@ -894,4 +895,64 @@ func extractComments(doc *html.Node, cache *lru.Cache, opts Options) (*html.Node
 	}
 
 	return nil, ""
+}
+
+func wordCount(text string) int {
+	count := 0
+	inWord := false
+
+	for _, r := range text {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			if !inWord {
+				count++
+				inWord = true
+			}
+		} else {
+			inWord = false
+		}
+	}
+
+	return count
+}
+
+func isLowQualityContent(n *html.Node, opts Options) bool {
+	longSentenceCount, wordListCount, totalWords := analyzeContentStructure(n, opts)
+
+	// Check for narrative (long-form) content
+	if hasSufficientNarrativeContent(longSentenceCount, opts) {
+		return false
+	}
+
+	// Check for structured content (e.g. dictionary word lists)
+	if hasSufficientStructuredContent(wordListCount, totalWords, opts) {
+		return false
+	}
+
+	// Fallback: assume low quality if neither heuristic is satisfied
+	return true
+}
+
+func analyzeContentStructure(n *html.Node, opts Options) (longSentences int, wordListBlocks int, totalWords int) {
+	for _, c := range dom.Children(n) {
+		txt := trim(etree.IterTextWithSpacing(c))
+		wc := wordCount(txt)
+		totalWords += wc
+
+		hasDot := strings.Contains(txt, ".")
+		if wc >= opts.Config.MinWordsPerSentence && hasDot {
+			longSentences++
+		} else if wc >= opts.Config.MinWordsPerStructuredBlock && !hasDot {
+			wordListBlocks++
+		}
+	}
+	return
+}
+
+func hasSufficientNarrativeContent(longSentences int, opts Options) bool {
+	return longSentences >= opts.Config.MinNarrativeSentences
+}
+
+func hasSufficientStructuredContent(wordListBlocks, totalWords int, opts Options) bool {
+	return wordListBlocks >= opts.Config.MinStructuredBlocks &&
+		totalWords >= opts.Config.MinTotalWords
 }

--- a/main-extractor.go
+++ b/main-extractor.go
@@ -643,9 +643,12 @@ func pruneUnwantedSections(subTree *html.Node, potentialTags map[string]struct{}
 	// Prune the rest
 	subTree = pruneUnwantedNodes(subTree, selector.OverallDiscardedContent, true)
 
+	tracePhrase("prune-unwanted-sections-first-pruning-step", subTree, opts)
+
 	// Prune images
 	if !opts.IncludeImages {
 		subTree = pruneUnwantedNodes(subTree, selector.DiscardedImage)
+		tracePhrase("prune-unwanted-sections-pruning-images-step", subTree, opts)
 	}
 
 	// Balance precision / recall
@@ -653,6 +656,7 @@ func pruneUnwantedSections(subTree *html.Node, potentialTags map[string]struct{}
 		subTree = pruneUnwantedNodes(subTree, selector.DiscardedTeaser)
 		if opts.Focus == FavorPrecision {
 			subTree = pruneUnwantedNodes(subTree, selector.PrecisionDiscardedContent)
+			tracePhrase("prune-unwanted-sections-pruning-precision-discarded-content-step", subTree, opts)
 		}
 	}
 
@@ -663,6 +667,8 @@ func pruneUnwantedSections(subTree *html.Node, potentialTags map[string]struct{}
 		deleteByLinkDensity(subTree, opts, false, "p")
 	}
 
+	tracePhrase("prune-unwanted-sections-pruning-by-link-density", subTree, opts)
+
 	// Remove tables by link density
 	if _, potential := potentialTags["table"]; potential || opts.Focus == FavorPrecision {
 		tables := etree.Iter(subTree, "table")
@@ -672,6 +678,8 @@ func pruneUnwantedSections(subTree *html.Node, potentialTags map[string]struct{}
 			}
 		}
 	}
+
+	tracePhrase("prune-unwanted-sections-pruning-by-tables-link-density", subTree, opts)
 
 	// Also filter fw/head, table and quote elements?
 	if opts.Focus == FavorPrecision {
@@ -688,6 +696,8 @@ func pruneUnwantedSections(subTree *html.Node, potentialTags map[string]struct{}
 		deleteByLinkDensity(subTree, opts, false, listXmlHeadTags...)
 		deleteByLinkDensity(subTree, opts, false, listXmlQuoteTags...)
 	}
+
+	tracePhrase("prune-unwanted-sections-pruning-by-other-things", subTree, opts)
 
 	return subTree
 }
@@ -728,10 +738,14 @@ func extractContent(doc *html.Node, cache *lru.Cache, opts Options) (*html.Node,
 			continue
 		}
 
+		tracePhrase("extract-content-selecting-content - X - before pruning", subTree, opts)
+
 		// Prune the subtree
 		subTree = pruneUnwantedSections(subTree, potentialTags, opts)
 		// TODO: second pass?
 		// deleteByLinkDensity(subTree, opts, false, listXmlListTags...)
+
+		tracePhrase("extract-content-selecting-content - X - after pruning", subTree, opts)
 
 		// If sub tree now empty, try other selector
 		if len(dom.Children(subTree)) == 0 {
@@ -820,10 +834,13 @@ func extractContent(doc *html.Node, cache *lru.Cache, opts Options) (*html.Node,
 		// we want to throw away the result body in the case we're recovering wild
 		// text because it's been too short so far, but we haven't missed too much paragraphs
 		if missingRatio < float64(opts.Config.MinExtractedParagraphPercent) {
+			log.Println("We haven't missed too much throwing away the results body")
 			resultBody = dom.CreateElement("body")
 		}
 		recoverWildText(backupDoc, resultBody, potentialTags, cache, opts)
 		tmpText = trim(etree.IterTextWithSpacing(resultBody))
+
+		tracePhrase("extract-content-wild-text-recovery", resultBody, opts)
 	}
 
 	// Filter output

--- a/main-extractor.go
+++ b/main-extractor.go
@@ -50,7 +50,7 @@ func handleTitles(element *html.Node, cache *lru.Cache, opts Options) *html.Node
 		}
 	}
 
-	if title != nil && textCharsTest(etree.IterText(title, " ")) {
+	if title != nil && textCharsTest(etree.IterTextWithSpacing(title)) {
 		return title
 	}
 
@@ -118,7 +118,7 @@ func processNestedElement(child, newChildElement *html.Node, cache *lru.Cache, o
 
 // isTextElement checks if the element contains text.
 func isTextElement(element *html.Node) bool {
-	return element != nil && textCharsTest(etree.IterText(element, " "))
+	return element != nil && textCharsTest(etree.IterTextWithSpacing(element))
 }
 
 // defineNewElement creates a new sub-element if necessary.
@@ -594,6 +594,14 @@ func recoverWildText(doc, resultBody *html.Node, potentialTags map[string]struct
 	selectorList = append(selectorList, listXmlQuoteTags...)
 	selectorList = append(selectorList, "code", "p", "table", `div[class*="w3-code"]`)
 
+	if opts.IncludeLists {
+		selectorList = append(selectorList, "ul", "ol", "dl", "li")
+	}
+
+	if opts.IncludeSpans {
+		selectorList = append(selectorList, "span")
+	}
+
 	if opts.Focus == FavorRecall {
 		potentialTags = maps.Clone(potentialTags)
 		potentialTags["div"] = struct{}{}
@@ -612,7 +620,7 @@ func recoverWildText(doc, resultBody *html.Node, potentialTags map[string]struct
 	// Decide if links are preserved
 	if _, exist := potentialTags["a"]; !exist {
 		etree.StripTags(searchDoc, "a", "ref", "span")
-	} else {
+	} else if _, exist := potentialTags["span"]; !exist {
 		etree.StripTags(searchDoc, "span")
 	}
 
@@ -732,7 +740,7 @@ func extractContent(doc *html.Node, cache *lru.Cache, opts Options) (*html.Node,
 		// Check if there are enough <p> with text
 		var paragraphText string
 		for _, p := range dom.GetElementsByTagName(doc, "p") {
-			paragraphText += dom.TextContent(p)
+			paragraphText += etree.IterTextWithSpacing(p)
 		}
 
 		factor := 3


### PR DESCRIPTION
**Changes**
1/ openai.com example was hitting the rescue path (using baseline.go) - that wasn't using the IterTextWithSpacing so was not having separated terms.
-  baseline.go is now using **etree.IterTextWithSpacing** instead of **dom.TextContent**