### PR TITLE
Comparison tooling for trafilatura

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,40 @@ test: generate
 	@echo "Test normal regex"
 	@echo
 	go test -timeout 30s ./...
+
+
+# -------- defaults (override on command line) --------
+IN ?=                     # required at runtime
+OUT ?= metrics.csv
+K ?= 5
+# cross-platform default for CPU count
+CONC ?= $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 8)
+URL_FROM ?= canonical     # canonical|filename|none
+EMIT_BODIES ?= false      # true to include body_a/body_b
+LIMIT ?=                  # e.g. 1000
+
+# turn booleans/optionals into CLI flags
+ifeq ($(strip $(EMIT_BODIES)),true)
+  EMIT_FLAG := --emit-bodies
+endif
+ifneq ($(strip $(LIMIT)),)
+  LIMIT_FLAG := --limit $(LIMIT)
+endif
+
+build-gt:
+	@go build -o go-trafilatura ./cmd/go-trafilatura
+
+compare: build-gt
+	@test -n "$(IN)" || { \
+		echo "Usage: make compare IN=/path/to/html [OUT=metrics.csv K=5 CONC=$(CONC) URL_FROM=$(URL_FROM) EMIT_BODIES=false LIMIT=]"; \
+		exit 2; \
+	}
+	@echo "Comparing control and variant of content extraction"
+	@echo
+	./go-trafilatura compare \
+	  --in "$(IN)" \
+	  --out "$(OUT)" \
+	  --k $(K) \
+	  --concurrency $(CONC) \
+	  --url-from $(URL_FROM) \
+	  $(EMIT_FLAG) $(LIMIT_FLAG)

--- a/cmd/go-trafilatura/compare.go
+++ b/cmd/go-trafilatura/compare.go
@@ -256,68 +256,6 @@ func likelyHTMLFile(path string) bool {
 		strings.Contains(b, "<head") || strings.Contains(b, "<body")
 }
 
-// -------- bucket thresholds & function ----------
-
-const (
-	thContainMuchBetter   = 0.95
-	thContainSlightBetter = 0.90
-	thContainSlightWorseL = 0.70
-)
-
-// labels
-const (
-	lMuchBetter   = "much_better"
-	lSlightBetter = "slightly_better"
-	lSame         = "same"
-	lSlightWorse  = "slightly_worse"
-	lMuchWorse    = "much_worse"
-	lError        = "error"
-)
-
-func bucket(m utils.Metrics) (label string, reason string) {
-	dupDelta := m.DupRatioB - m.DupRatioA
-
-	// much worse
-	if m.ContainmentAinB < thContainSlightWorseL || m.Jaccard < 0.70 ||
-		m.DeltaTokens <= -100 || m.DeltaSent <= -3 || dupDelta > 0.10 ||
-		(m.AShingles > 0 && m.BShingles == 0) {
-		return lMuchWorse, "drop/empty/large_dup_increase"
-	}
-
-	// slightly worse
-	if (m.ContainmentAinB >= thContainSlightWorseL && m.ContainmentAinB < thContainSlightBetter) ||
-		m.DeltaTokens <= -30 || m.DeltaSent <= -1 ||
-		(dupDelta > 0.03 && dupDelta <= 0.10) {
-		return lSlightWorse, "partial_drop_or_dup_increase"
-	}
-
-	// same
-	if m.Jaccard >= 0.98 || (m.ContainmentAinB >= 0.98 && m.ContainmentBinA >= 0.98) {
-		if m.AShingles == 0 && m.BShingles == 0 {
-			return lSame, "both_empty"
-		}
-		return lSame, "sameish"
-	}
-
-	// slightly better
-	if m.ContainmentAinB >= thContainSlightBetter &&
-		m.NovelBminusA >= 0.05 && m.NovelBminusA < 0.15 &&
-		dupDelta <= 0.03 &&
-		(m.DeltaTokens >= 10 || m.DeltaSent >= 1) {
-		return lSlightBetter, "minor_gain_low_dup"
-	}
-
-	// much better
-	if m.ContainmentAinB >= thContainMuchBetter &&
-		m.NovelBminusA >= 0.15 &&
-		dupDelta <= 0.02 &&
-		(m.DeltaTokens >= 50 || m.DeltaSent >= 2) {
-		return lMuchBetter, "clear_gain_low_dup"
-	}
-
-	return lSame, "default_same"
-}
-
 // -------- CSV writer + summary ----------
 
 func writeCSV(path string, results <-chan res, emitBodies bool) error {
@@ -357,7 +295,7 @@ func writeCSV(path string, results <-chan res, emitBodies bool) error {
 		if r.err != nil {
 			rec := []string{r.url, r.file}
 			rec = append(rec, make([]string, 12)...) // metrics blanks
-			rec = append(rec, lError, "error:"+r.err.Error())
+			rec = append(rec, utils.LError, "error:"+r.err.Error())
 			if emitBodies {
 				rec = append(rec, "", "")
 			}
@@ -367,7 +305,7 @@ func writeCSV(path string, results <-chan res, emitBodies bool) error {
 			continue
 		}
 
-		lab, note := bucket(r.m)
+		lab, note := utils.Bucket(r.m)
 		rec := []string{
 			r.url, r.file,
 			fmtf(r.m.ContainmentAinB),
@@ -427,7 +365,7 @@ func summarizeCSV(path string) {
 		}
 	}
 	// stable order in summary
-	labels := []string{lMuchBetter, lSlightBetter, lSame, lSlightWorse, lMuchWorse, lError}
+	labels := []string{utils.LMuchBetter, utils.LSlightBetter, utils.LSame, utils.LSlightWorse, utils.LMuchWorse, utils.LError}
 	fmt.Fprintf(os.Stderr,
 		"bucket summary: %s=%d %s=%d %s=%d %s=%d %s=%d %s=%d (n=%d)\n",
 		labels[0], counts[labels[0]],

--- a/cmd/go-trafilatura/compare.go
+++ b/cmd/go-trafilatura/compare.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ONE type definition for results (avoid duplicate anonymous/nested types).
+// worker result
 type res struct {
 	url, file    string
 	bodyA, bodyB string
@@ -51,7 +51,7 @@ func compareCmd() *cobra.Command {
 				return err
 			}
 			if len(files) == 0 {
-				return fmt.Errorf("no .html files under %s", inDir)
+				return fmt.Errorf("no HTML-like files under %s", inDir)
 			}
 
 			// -------- Define your two option sets here (hard-coded) --------
@@ -65,7 +65,7 @@ func compareCmd() *cobra.Command {
 					MinExtractedCommentSize:      1,
 					MinOutputSize:                0,
 					MinOutputCommentSize:         0,
-					MinExtractedParagraphPercent: 0.25, // your forked heuristic
+					MinExtractedParagraphPercent: 0.25, // fork heuristic
 				},
 				ExcludeComments:     false,
 				IncludeImages:       false,
@@ -74,7 +74,7 @@ func compareCmd() *cobra.Command {
 				EnableFallback:      false,
 				HtmlDateMode:        trafilatura.Disabled, // perf leak avoided
 				FilterCookieBanners: true,
-				// OriginalURL will be set per-document below
+				// OriginalURL set per-document below
 			}
 
 			// B: tweak only what you're testing (edit as needed)
@@ -96,8 +96,7 @@ func compareCmd() *cobra.Command {
 				EnableFallback:      false,
 				HtmlDateMode:        trafilatura.Disabled,
 				FilterCookieBanners: true,
-				// Example change: enable dedup or some new heuristic you’re testing
-				// Deduplicate is a flag on Options, not Config, if you use it:
+				// Example toggle under test:
 				// Deduplicate: true,
 			}
 
@@ -123,7 +122,7 @@ func compareCmd() *cobra.Command {
 							continue
 						}
 
-						// Derive URL string from HTML or file path, set OriginalURL on both opts
+						// Derive URL string, set OriginalURL on both option sets
 						uStr := deriveURL(urlFrom, j.path, htmlBytes)
 						var parsed *url.URL
 						if uStr != "" {
@@ -131,7 +130,8 @@ func compareCmd() *cobra.Command {
 								parsed = pu
 							}
 						}
-						// Copy the base options per doc (avoid sharing pointer fields across goroutines)
+
+						// Copy per doc (avoid sharing pointers across goroutines)
 						a := optsA
 						b := optsB
 						a.OriginalURL = parsed
@@ -150,7 +150,7 @@ func compareCmd() *cobra.Command {
 							continue
 						}
 
-						// Render body text with the same pipeline as the CLI
+						// Render body text via the same pipeline the CLI uses
 						var bufA, bufB bytes.Buffer
 						if err := writeOutput(&bufA, rA, txtCmd); err != nil {
 							out <- res{file: j.path, url: uStr, err: fmt.Errorf("render A: %v", err)}
@@ -190,12 +190,13 @@ func compareCmd() *cobra.Command {
 				return err
 			}
 			log.Info().Msgf("wrote %s", outCSV)
+			summarizeCSV(outCSV)
 			return nil
 		},
 	}
 
 	// Basic args only (A/B options are hard-coded above)
-	cmd.Flags().StringVar(&inDir, "in", "", "Directory with .html files (recursed)")
+	cmd.Flags().StringVar(&inDir, "in", "", "Directory with HTML files (recursed)")
 	cmd.Flags().StringVar(&outCSV, "out", "metrics.csv", "Output CSV path")
 	cmd.Flags().IntVar(&k, "k", 5, "Shingle size k (default 5)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", runtime.NumCPU(), "Parallel workers")
@@ -206,10 +207,12 @@ func compareCmd() *cobra.Command {
 	return cmd
 }
 
-// -------- file walking & CSV ----------
+// -------- file walking (extension + sniff) ----------
 
 func walkHTML(dir string, limit int) ([]string, error) {
+	suffixes := []string{".html", ".htm", ".xhtml", ".shtml"}
 	var files []string
+
 	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -218,7 +221,14 @@ func walkHTML(dir string, limit int) ([]string, error) {
 			return nil
 		}
 		name := strings.ToLower(d.Name())
-		if strings.HasSuffix(name, ".html") || strings.HasSuffix(name, ".htm") {
+		for _, sfx := range suffixes {
+			if strings.HasSuffix(name, sfx) {
+				files = append(files, path)
+				return nil
+			}
+		}
+		// quick content sniff for HTML-like files without a typical extension
+		if likelyHTMLFile(path) {
 			files = append(files, path)
 		}
 		return nil
@@ -232,6 +242,83 @@ func walkHTML(dir string, limit int) ([]string, error) {
 	}
 	return files, nil
 }
+
+func likelyHTMLFile(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	buf := make([]byte, 4096)
+	n, _ := f.Read(buf)
+	b := strings.ToLower(string(buf[:n]))
+	return strings.Contains(b, "<html") || strings.Contains(b, "<!doctype") ||
+		strings.Contains(b, "<head") || strings.Contains(b, "<body")
+}
+
+// -------- bucket thresholds & function ----------
+
+const (
+	thContainMuchBetter   = 0.95
+	thContainSlightBetter = 0.90
+	thContainSlightWorseL = 0.70
+)
+
+// labels
+const (
+	lMuchBetter   = "much_better"
+	lSlightBetter = "slightly_better"
+	lSame         = "same"
+	lSlightWorse  = "slightly_worse"
+	lMuchWorse    = "much_worse"
+	lError        = "error"
+)
+
+func bucket(m utils.Metrics) (label string, reason string) {
+	dupDelta := m.DupRatioB - m.DupRatioA
+
+	// much worse
+	if m.ContainmentAinB < thContainSlightWorseL || m.Jaccard < 0.70 ||
+		m.DeltaTokens <= -100 || m.DeltaSent <= -3 || dupDelta > 0.10 ||
+		(m.AShingles > 0 && m.BShingles == 0) {
+		return lMuchWorse, "drop/empty/large_dup_increase"
+	}
+
+	// slightly worse
+	if (m.ContainmentAinB >= thContainSlightWorseL && m.ContainmentAinB < thContainSlightBetter) ||
+		m.DeltaTokens <= -30 || m.DeltaSent <= -1 ||
+		(dupDelta > 0.03 && dupDelta <= 0.10) {
+		return lSlightWorse, "partial_drop_or_dup_increase"
+	}
+
+	// same
+	if m.Jaccard >= 0.98 || (m.ContainmentAinB >= 0.98 && m.ContainmentBinA >= 0.98) {
+		if m.AShingles == 0 && m.BShingles == 0 {
+			return lSame, "both_empty"
+		}
+		return lSame, "sameish"
+	}
+
+	// slightly better
+	if m.ContainmentAinB >= thContainSlightBetter &&
+		m.NovelBminusA >= 0.05 && m.NovelBminusA < 0.15 &&
+		dupDelta <= 0.03 &&
+		(m.DeltaTokens >= 10 || m.DeltaSent >= 1) {
+		return lSlightBetter, "minor_gain_low_dup"
+	}
+
+	// much better
+	if m.ContainmentAinB >= thContainMuchBetter &&
+		m.NovelBminusA >= 0.15 &&
+		dupDelta <= 0.02 &&
+		(m.DeltaTokens >= 50 || m.DeltaSent >= 2) {
+		return lMuchBetter, "clear_gain_low_dup"
+	}
+
+	return lSame, "default_same"
+}
+
+// -------- CSV writer + summary ----------
 
 func writeCSV(path string, results <-chan res, emitBodies bool) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil && !os.IsExist(err) {
@@ -251,6 +338,7 @@ func writeCSV(path string, results <-chan res, emitBodies bool) error {
 		"delta_tokens", "delta_chars", "delta_sentences",
 		"dup_ratio_A", "dup_ratio_B",
 		"A_shingles", "B_shingles", "intersection", "union",
+		"bucket", "note",
 	}
 	if emitBodies {
 		header = append(header, "body_a", "body_b")
@@ -268,7 +356,8 @@ func writeCSV(path string, results <-chan res, emitBodies bool) error {
 	for _, r := range rows {
 		if r.err != nil {
 			rec := []string{r.url, r.file}
-			rec = append(rec, make([]string, 12)...)
+			rec = append(rec, make([]string, 12)...) // metrics blanks
+			rec = append(rec, lError, "error:"+r.err.Error())
 			if emitBodies {
 				rec = append(rec, "", "")
 			}
@@ -277,6 +366,8 @@ func writeCSV(path string, results <-chan res, emitBodies bool) error {
 			}
 			continue
 		}
+
+		lab, note := bucket(r.m)
 		rec := []string{
 			r.url, r.file,
 			fmtf(r.m.ContainmentAinB),
@@ -292,6 +383,7 @@ func writeCSV(path string, results <-chan res, emitBodies bool) error {
 			fmt.Sprintf("%d", r.m.BShingles),
 			fmt.Sprintf("%d", r.m.Intersection),
 			fmt.Sprintf("%d", r.m.Union),
+			lab, note,
 		}
 		if emitBodies {
 			rec = append(rec, r.bodyA, r.bodyB)
@@ -301,6 +393,51 @@ func writeCSV(path string, results <-chan res, emitBodies bool) error {
 		}
 	}
 	return nil
+}
+
+func summarizeCSV(path string) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	r := csv.NewReader(f)
+	rows, err := r.ReadAll()
+	if err != nil || len(rows) <= 1 {
+		return
+	}
+	// find bucket column
+	hdr := rows[0]
+	bi := -1
+	for i, h := range hdr {
+		if h == "bucket" {
+			bi = i
+			break
+		}
+	}
+	if bi < 0 {
+		return
+	}
+	counts := map[string]int{}
+	total := 0
+	for _, rec := range rows[1:] {
+		if len(rec) > bi {
+			counts[rec[bi]]++
+			total++
+		}
+	}
+	// stable order in summary
+	labels := []string{lMuchBetter, lSlightBetter, lSame, lSlightWorse, lMuchWorse, lError}
+	fmt.Fprintf(os.Stderr,
+		"bucket summary: %s=%d %s=%d %s=%d %s=%d %s=%d %s=%d (n=%d)\n",
+		labels[0], counts[labels[0]],
+		labels[1], counts[labels[1]],
+		labels[2], counts[labels[2]],
+		labels[3], counts[labels[3]],
+		labels[4], counts[labels[4]],
+		labels[5], counts[labels[5]],
+		total,
+	)
 }
 
 // -------- URL derivation (for CSV & OriginalURL) ----------
@@ -328,6 +465,8 @@ func deriveURL(mode, htmlPath string, html []byte) string {
 		return "file://" + filepath.ToSlash(htmlPath)
 	}
 }
+
+// small float formatter
 func fmtf(f float64) string {
 	return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.6f", f), "0"), ".")
 }

--- a/cmd/go-trafilatura/compare.go
+++ b/cmd/go-trafilatura/compare.go
@@ -1,0 +1,333 @@
+package main
+
+import (
+	"bytes"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/markusmobius/go-trafilatura"
+	"github.com/markusmobius/go-trafilatura/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+// ONE type definition for results (avoid duplicate anonymous/nested types).
+type res struct {
+	url, file    string
+	bodyA, bodyB string
+	m            utils.Metrics
+	err          error
+}
+
+func compareCmd() *cobra.Command {
+	var (
+		inDir       string
+		outCSV      string
+		k           int
+		concurrency int
+		urlFrom     string // canonical|filename|none
+		emitBodies  bool
+		limit       int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "compare",
+		Short: "Run A/B extraction on a directory of HTML and export quality metrics to CSV",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if inDir == "" {
+				return errors.New("-in is required")
+			}
+			files, err := walkHTML(inDir, limit)
+			if err != nil {
+				return err
+			}
+			if len(files) == 0 {
+				return fmt.Errorf("no .html files under %s", inDir)
+			}
+
+			// -------- Define your two option sets here (hard-coded) --------
+			// A: mirrors your production-ish defaults
+			optsA := trafilatura.Options{
+				Config: &trafilatura.Config{
+					CacheSize:                    4096,
+					MinDuplicateCheckSize:        100,
+					MaxDuplicateCount:            2,
+					MinExtractedSize:             250,
+					MinExtractedCommentSize:      1,
+					MinOutputSize:                0,
+					MinOutputCommentSize:         0,
+					MinExtractedParagraphPercent: 0.25, // your forked heuristic
+				},
+				ExcludeComments:     false,
+				IncludeImages:       false,
+				IncludeLinks:        false,
+				EnableLog:           false,
+				EnableFallback:      false,
+				HtmlDateMode:        trafilatura.Disabled, // perf leak avoided
+				FilterCookieBanners: true,
+				// OriginalURL will be set per-document below
+			}
+
+			// B: tweak only what you're testing (edit as needed)
+			optsB := trafilatura.Options{
+				Config: &trafilatura.Config{
+					CacheSize:                    4096,
+					MinDuplicateCheckSize:        100,
+					MaxDuplicateCount:            2,
+					MinExtractedSize:             250,
+					MinExtractedCommentSize:      1,
+					MinOutputSize:                0,
+					MinOutputCommentSize:         0,
+					MinExtractedParagraphPercent: 0.25,
+				},
+				ExcludeComments:     false,
+				IncludeImages:       false,
+				IncludeLinks:        false,
+				EnableLog:           false,
+				EnableFallback:      false,
+				HtmlDateMode:        trafilatura.Disabled,
+				FilterCookieBanners: true,
+				// Example change: enable dedup or some new heuristic you’re testing
+				// Deduplicate is a flag on Options, not Config, if you use it:
+				// Deduplicate: true,
+			}
+
+			// Worker pool
+			type job struct{ path string }
+			jobs := make(chan job)
+			out := make(chan res)
+			var wg sync.WaitGroup
+
+			// Force writeOutput to produce TXT like the main command would
+			txtCmd := &cobra.Command{}
+			txtCmd.Flags().String("format", "txt", "")
+			_ = txtCmd.Flags().Set("format", "txt")
+
+			for i := 0; i < concurrency; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for j := range jobs {
+						htmlBytes, err := os.ReadFile(j.path)
+						if err != nil {
+							out <- res{file: j.path, err: err}
+							continue
+						}
+
+						// Derive URL string from HTML or file path, set OriginalURL on both opts
+						uStr := deriveURL(urlFrom, j.path, htmlBytes)
+						var parsed *url.URL
+						if uStr != "" {
+							if pu, perr := url.Parse(uStr); perr == nil {
+								parsed = pu
+							}
+						}
+						// Copy the base options per doc (avoid sharing pointer fields across goroutines)
+						a := optsA
+						b := optsB
+						a.OriginalURL = parsed
+						b.OriginalURL = parsed
+
+						// Extract A
+						rA, errA := processFile(j.path, a)
+						if errA != nil || rA == nil {
+							out <- res{file: j.path, url: uStr, err: fmt.Errorf("A: %v", errA)}
+							continue
+						}
+						// Extract B
+						rB, errB := processFile(j.path, b)
+						if errB != nil || rB == nil {
+							out <- res{file: j.path, url: uStr, err: fmt.Errorf("B: %v", errB)}
+							continue
+						}
+
+						// Render body text with the same pipeline as the CLI
+						var bufA, bufB bytes.Buffer
+						if err := writeOutput(&bufA, rA, txtCmd); err != nil {
+							out <- res{file: j.path, url: uStr, err: fmt.Errorf("render A: %v", err)}
+							continue
+						}
+						if err := writeOutput(&bufB, rB, txtCmd); err != nil {
+							out <- res{file: j.path, url: uStr, err: fmt.Errorf("render B: %v", err)}
+							continue
+						}
+						bodyA := bufA.String()
+						bodyB := bufB.String()
+
+						// Metrics
+						m := utils.ComputeMetrics(bodyA, bodyB, k)
+
+						out <- res{
+							url: uStr, file: j.path, bodyA: bodyA, bodyB: bodyB, m: m,
+						}
+					}
+				}()
+			}
+
+			go func() {
+				for _, f := range files {
+					jobs <- job{path: f}
+				}
+				close(jobs)
+				wg.Wait()
+				close(out)
+			}()
+
+			// Write CSV
+			if outCSV == "" {
+				outCSV = "metrics.csv"
+			}
+			if err := writeCSV(outCSV, out, emitBodies); err != nil {
+				return err
+			}
+			log.Info().Msgf("wrote %s", outCSV)
+			return nil
+		},
+	}
+
+	// Basic args only (A/B options are hard-coded above)
+	cmd.Flags().StringVar(&inDir, "in", "", "Directory with .html files (recursed)")
+	cmd.Flags().StringVar(&outCSV, "out", "metrics.csv", "Output CSV path")
+	cmd.Flags().IntVar(&k, "k", 5, "Shingle size k (default 5)")
+	cmd.Flags().IntVar(&concurrency, "concurrency", runtime.NumCPU(), "Parallel workers")
+	cmd.Flags().StringVar(&urlFrom, "url-from", "canonical", "URL source: canonical|filename|none")
+	cmd.Flags().BoolVar(&emitBodies, "emit-bodies", false, "Include body_a/body_b in CSV")
+	cmd.Flags().IntVar(&limit, "limit", 0, "Max HTML files to process (0=all)")
+
+	return cmd
+}
+
+// -------- file walking & CSV ----------
+
+func walkHTML(dir string, limit int) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		name := strings.ToLower(d.Name())
+		if strings.HasSuffix(name, ".html") || strings.HasSuffix(name, ".htm") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(files)
+	if limit > 0 && len(files) > limit {
+		files = files[:limit]
+	}
+	return files, nil
+}
+
+func writeCSV(path string, results <-chan res, emitBodies bool) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil && !os.IsExist(err) {
+		return err
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := csv.NewWriter(f)
+	defer w.Flush()
+
+	header := []string{
+		"url", "file",
+		"containment_A_in_B", "containment_B_in_A", "jaccard", "novel_B_minus_A",
+		"delta_tokens", "delta_chars", "delta_sentences",
+		"dup_ratio_A", "dup_ratio_B",
+		"A_shingles", "B_shingles", "intersection", "union",
+	}
+	if emitBodies {
+		header = append(header, "body_a", "body_b")
+	}
+	if err := w.Write(header); err != nil {
+		return err
+	}
+
+	var rows []res
+	for r := range results {
+		rows = append(rows, r)
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].file < rows[j].file })
+
+	for _, r := range rows {
+		if r.err != nil {
+			rec := []string{r.url, r.file}
+			rec = append(rec, make([]string, 12)...)
+			if emitBodies {
+				rec = append(rec, "", "")
+			}
+			if err := w.Write(rec); err != nil {
+				return err
+			}
+			continue
+		}
+		rec := []string{
+			r.url, r.file,
+			fmtf(r.m.ContainmentAinB),
+			fmtf(r.m.ContainmentBinA),
+			fmtf(r.m.Jaccard),
+			fmtf(r.m.NovelBminusA),
+			fmt.Sprintf("%d", r.m.DeltaTokens),
+			fmt.Sprintf("%d", r.m.DeltaChars),
+			fmt.Sprintf("%d", r.m.DeltaSent),
+			fmtf(r.m.DupRatioA),
+			fmtf(r.m.DupRatioB),
+			fmt.Sprintf("%d", r.m.AShingles),
+			fmt.Sprintf("%d", r.m.BShingles),
+			fmt.Sprintf("%d", r.m.Intersection),
+			fmt.Sprintf("%d", r.m.Union),
+		}
+		if emitBodies {
+			rec = append(rec, r.bodyA, r.bodyB)
+		}
+		if err := w.Write(rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// -------- URL derivation (for CSV & OriginalURL) ----------
+
+var (
+	reCanonical = regexp.MustCompile(`(?is)<link[^>]+rel=['"]canonical['"][^>]+href=['"]([^'"]+)`)
+	reOGURL     = regexp.MustCompile(`(?is)<meta[^>]+property=['"]og:url['"][^>]+content=['"]([^'"]+)`)
+)
+
+func deriveURL(mode, htmlPath string, html []byte) string {
+	switch mode {
+	case "canonical":
+		if m := reCanonical.FindSubmatch(html); len(m) == 2 {
+			return string(m[1])
+		}
+		if m := reOGURL.FindSubmatch(html); len(m) == 2 {
+			return string(m[1])
+		}
+		fallthrough
+	case "filename":
+		return "file://" + filepath.ToSlash(htmlPath)
+	case "none":
+		return ""
+	default:
+		return "file://" + filepath.ToSlash(htmlPath)
+	}
+}
+func fmtf(f float64) string {
+	return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.6f", f), "0"), ".")
+}

--- a/cmd/go-trafilatura/main.go
+++ b/cmd/go-trafilatura/main.go
@@ -78,7 +78,7 @@ func main() {
 	flags.StringP("user-agent", "u", defaultUserAgent, "set custom user agent")
 
 	// Add sub commands
-	rootCmd.AddCommand(batchCmd(), sitemapCmd(), feedCmd())
+	rootCmd.AddCommand(batchCmd(), sitemapCmd(), feedCmd(), compareCmd()) // <-- add compareCmd()
 
 	// Execute
 	err := rootCmd.Execute()

--- a/internal/utils/compute_metrics.go
+++ b/internal/utils/compute_metrics.go
@@ -1,9 +1,95 @@
 package utils
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 )
+
+// -----------------------------
+// Bucketing (exported)
+// -----------------------------
+
+// Thresholds (exported so callers can keep CSV summaries consistent)
+const (
+	ThContainMuchBetter   = 0.95
+	ThContainSlightBetter = 0.90
+	ThContainSlightWorseL = 0.70
+)
+
+// Labels (exported for CSV & summaries)
+const (
+	LMuchBetter   = "much_better"
+	LSlightBetter = "slightly_better"
+	LSame         = "same"
+	LSlightWorse  = "slightly_worse"
+	LMuchWorse    = "much_worse"
+	LError        = "error"
+)
+
+// Bucket assigns a coarse label and reason for an A/B extraction delta, using Metrics.
+// This mirrors the previous CLI-local logic so downstream tooling can rely on a single source of truth.
+
+// labels
+
+const (
+	thContainMuchBetter   = 0.95
+	thContainSlightBetter = 0.90
+	thContainSlightWorseL = 0.70
+)
+
+const (
+	lMuchBetter   = "much_better"
+	lSlightBetter = "slightly_better"
+	lSame         = "same"
+	lSlightWorse  = "slightly_worse"
+	lMuchWorse    = "much_worse"
+	lError        = "error"
+)
+
+func Bucket(m Metrics) (label string, reason string) {
+	dupDelta := m.DupRatioB - m.DupRatioA
+
+	// much worse
+	if m.ContainmentAinB < thContainSlightWorseL || m.Jaccard < 0.70 ||
+		m.DeltaTokens <= -100 || m.DeltaSent <= -3 || dupDelta > 0.10 ||
+		(m.AShingles > 0 && m.BShingles == 0) {
+		return lMuchWorse, "drop/empty/large_dup_increase"
+	}
+
+	// slightly worse
+	if (m.ContainmentAinB >= thContainSlightWorseL && m.ContainmentAinB < thContainSlightBetter) ||
+		m.DeltaTokens <= -30 || m.DeltaSent <= -1 ||
+		(dupDelta > 0.03 && dupDelta <= 0.10) {
+		return lSlightWorse, "partial_drop_or_dup_increase"
+	}
+
+	// same
+	if m.Jaccard >= 0.98 || (m.ContainmentAinB >= 0.98 && m.ContainmentBinA >= 0.98) {
+		if m.AShingles == 0 && m.BShingles == 0 {
+			return lSame, "both_empty"
+		}
+		return lSame, "sameish"
+	}
+
+	// slightly better
+	if m.ContainmentAinB >= thContainSlightBetter &&
+		m.NovelBminusA >= 0.05 && m.NovelBminusA < 0.15 &&
+		dupDelta <= 0.03 &&
+		(m.DeltaTokens >= 10 || m.DeltaSent >= 1) {
+		return lSlightBetter, "minor_gain_low_dup"
+	}
+
+	// much better
+	if m.ContainmentAinB >= thContainMuchBetter &&
+		m.NovelBminusA >= 0.15 &&
+		dupDelta <= 0.02 &&
+		(m.DeltaTokens >= 50 || m.DeltaSent >= 2) {
+		return lMuchBetter, "clear_gain_low_dup"
+	}
+
+	return lSame, "default_same"
+}
 
 type Metrics struct {
 	ContainmentAinB float64 `json:"containment_A_in_B"`
@@ -185,4 +271,9 @@ func sentenceCount(s string) int {
 		}
 	}
 	return count
+}
+
+// small helper kept here to avoid duplicating tiny formatters in callers
+func fmtf(f float64) string {
+	return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.6f", f), "0"), ".")
 }

--- a/internal/utils/compute_metrics.go
+++ b/internal/utils/compute_metrics.go
@@ -27,32 +27,35 @@ type Metrics struct {
 func ComputeMetrics(bodyA, bodyB string, k int) Metrics {
 	A := normalize(bodyA)
 	B := normalize(bodyB)
+
 	Atok := tokenize(A)
 	Btok := tokenize(B)
+
 	Alist, Aset := shingleHashes(Atok, k)
 	Blist, Bset := shingleHashes(Btok, k)
+
 	inter := intersectCount(Aset, Bset)
 	uni := len(Aset) + len(Bset) - inter
 
 	var containAinB, containBinA, jaccard, novel float64
-	if len(Aset) == 0 {
-		containAinB = 1
-	} else {
+	switch {
+	case len(Aset) == 0 && len(Bset) == 0:
+		// Both empty => identical
+		containAinB, containBinA, jaccard, novel = 1.0, 1.0, 1.0, 0.0
+	case len(Aset) == 0 && len(Bset) > 0:
+		// Empty contained in anything; Jaccard 0, all of B is novel
+		containAinB, containBinA, jaccard, novel = 1.0, 0.0, 0.0, 1.0
+	case len(Bset) == 0 && len(Aset) > 0:
+		// Symmetric case
+		containAinB, containBinA, jaccard, novel = 0.0, 1.0, 0.0, 0.0
+	default:
 		containAinB = float64(inter) / float64(len(Aset))
-	}
-	if len(Bset) == 0 {
-		containBinA = 1
-	} else {
 		containBinA = float64(inter) / float64(len(Bset))
-	}
-	if uni == 0 {
-		jaccard = 1
-	} else {
-		jaccard = float64(inter) / float64(uni)
-	}
-	if len(Bset) == 0 {
-		novel = 0
-	} else {
+		if uni == 0 {
+			jaccard = 1.0
+		} else {
+			jaccard = float64(inter) / float64(uni)
+		}
 		novel = float64(len(Bset)-inter) / float64(len(Bset))
 	}
 
@@ -61,44 +64,64 @@ func ComputeMetrics(bodyA, bodyB string, k int) Metrics {
 		ContainmentBinA: containBinA,
 		Jaccard:         jaccard,
 		NovelBminusA:    novel,
-		DeltaTokens:     len(Btok) - len(Atok),
-		DeltaChars:      len(B) - len(A),
-		DeltaSent:       sentenceCount(B) - sentenceCount(A),
-		DupRatioA:       duplicationRatio(Alist),
-		DupRatioB:       duplicationRatio(Blist),
-		AShingles:       len(Aset),
-		BShingles:       len(Bset),
-		Intersection:    inter,
-		Union:           uni,
+
+		DeltaTokens: len(Btok) - len(Atok),
+		DeltaChars:  len(B) - len(A),
+		DeltaSent:   sentenceCount(B) - sentenceCount(A),
+
+		DupRatioA: duplicationRatio(Alist),
+		DupRatioB: duplicationRatio(Blist),
+
+		AShingles:    len(Aset),
+		BShingles:    len(Bset),
+		Intersection: inter,
+		Union:        uni,
 	}
 }
+
+// --- Text processing helpers ---
 
 var wordReCompare = regexp.MustCompile(`\p{L}+|\p{N}+`)
 
 func normalize(s string) string {
+	// Normalize newlines, collapse all whitespace runs to single spaces, and trim
 	s = strings.ReplaceAll(s, "\r\n", "\n")
 	s = strings.ReplaceAll(s, "\r", "\n")
 	return strings.TrimSpace(strings.Join(strings.Fields(s), " "))
 }
+
 func tokenize(s string) []string {
 	return wordReCompare.FindAllString(strings.ToLower(s), -1)
 }
+
+// shingleHashes returns both the sequential list of shingle hashes (for duplication ratio)
+// and a set of unique shingle hashes (for set metrics).
+//
+// FIX: When len(tokens) < k but > 0, emit a single shingle from all tokens.
+// This prevents empty-shingle edge cases from producing misleading similarity.
 func shingleHashes(tokens []string, k int) ([]uint64, map[uint64]struct{}) {
 	if k <= 0 {
 		panic("k must be >= 1")
 	}
-	if len(tokens) < k {
+	switch {
+	case len(tokens) == 0:
 		return nil, map[uint64]struct{}{}
+	case len(tokens) < k:
+		joined := strings.Join(tokens, " ")
+		h := fnv64a(joined)
+		return []uint64{h}, map[uint64]struct{}{h: {}}
+	default:
+		list := make([]uint64, 0, len(tokens)-k+1)
+		set := make(map[uint64]struct{}, cap(list))
+		for i := 0; i <= len(tokens)-k; i++ {
+			h := fnv64a(strings.Join(tokens[i:i+k], " "))
+			list = append(list, h)
+			set[h] = struct{}{}
+		}
+		return list, set
 	}
-	list := make([]uint64, 0, len(tokens)-k+1)
-	set := make(map[uint64]struct{}, cap(list))
-	for i := 0; i <= len(tokens)-k; i++ {
-		h := fnv64a(strings.Join(tokens[i:i+k], " "))
-		list = append(list, h)
-		set[h] = struct{}{}
-	}
-	return list, set
 }
+
 func fnv64a(s string) uint64 {
 	const (
 		offset64 = 1469598103934665603
@@ -111,10 +134,12 @@ func fnv64a(s string) uint64 {
 	}
 	return hash
 }
+
 func intersectCount(a, b map[uint64]struct{}) int {
 	if len(a) == 0 || len(b) == 0 {
 		return 0
 	}
+	// iterate smaller set
 	if len(a) > len(b) {
 		a, b = b, a
 	}
@@ -126,6 +151,7 @@ func intersectCount(a, b map[uint64]struct{}) int {
 	}
 	return c
 }
+
 func duplicationRatio(list []uint64) float64 {
 	if len(list) == 0 {
 		return 0
@@ -136,14 +162,27 @@ func duplicationRatio(list []uint64) float64 {
 	}
 	return float64(len(list)-len(seen)) / float64(len(list))
 }
+
+// sentenceCount counts sequences of terminal punctuation ('.', '!', '?')
+// as a single sentence end. So "what?!" and "Really???" each count as 1.
+//
+// Examples:
+//
+//	"Wait... what?! Really???" -> 3
+//	"Paragraph one.\n\nParagraph two.\nSame paragraph continued." -> 2
 func sentenceCount(s string) int {
-	re := regexp.MustCompile(`[.!?]+|\n+`)
-	parts := re.Split(s, -1)
-	n := 0
-	for _, p := range parts {
-		if strings.TrimSpace(p) != "" {
-			n++
+	count := 0
+	inTermRun := false
+	for _, r := range s {
+		switch r {
+		case '.', '!', '?':
+			if !inTermRun {
+				count++
+				inTermRun = true
+			}
+		default:
+			inTermRun = false
 		}
 	}
-	return n
+	return count
 }

--- a/internal/utils/compute_metrics.go
+++ b/internal/utils/compute_metrics.go
@@ -1,0 +1,149 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+type Metrics struct {
+	ContainmentAinB float64 `json:"containment_A_in_B"`
+	ContainmentBinA float64 `json:"containment_B_in_A"`
+	Jaccard         float64 `json:"jaccard"`
+	NovelBminusA    float64 `json:"novel_B_minus_A"`
+
+	DeltaTokens int `json:"delta_tokens"`
+	DeltaChars  int `json:"delta_chars"`
+	DeltaSent   int `json:"delta_sentences"`
+
+	DupRatioA float64 `json:"dup_ratio_A"`
+	DupRatioB float64 `json:"dup_ratio_B"`
+
+	AShingles    int `json:"A_shingles"`
+	BShingles    int `json:"B_shingles"`
+	Intersection int `json:"intersection"`
+	Union        int `json:"union"`
+}
+
+func ComputeMetrics(bodyA, bodyB string, k int) Metrics {
+	A := normalize(bodyA)
+	B := normalize(bodyB)
+	Atok := tokenize(A)
+	Btok := tokenize(B)
+	Alist, Aset := shingleHashes(Atok, k)
+	Blist, Bset := shingleHashes(Btok, k)
+	inter := intersectCount(Aset, Bset)
+	uni := len(Aset) + len(Bset) - inter
+
+	var containAinB, containBinA, jaccard, novel float64
+	if len(Aset) == 0 {
+		containAinB = 1
+	} else {
+		containAinB = float64(inter) / float64(len(Aset))
+	}
+	if len(Bset) == 0 {
+		containBinA = 1
+	} else {
+		containBinA = float64(inter) / float64(len(Bset))
+	}
+	if uni == 0 {
+		jaccard = 1
+	} else {
+		jaccard = float64(inter) / float64(uni)
+	}
+	if len(Bset) == 0 {
+		novel = 0
+	} else {
+		novel = float64(len(Bset)-inter) / float64(len(Bset))
+	}
+
+	return Metrics{
+		ContainmentAinB: containAinB,
+		ContainmentBinA: containBinA,
+		Jaccard:         jaccard,
+		NovelBminusA:    novel,
+		DeltaTokens:     len(Btok) - len(Atok),
+		DeltaChars:      len(B) - len(A),
+		DeltaSent:       sentenceCount(B) - sentenceCount(A),
+		DupRatioA:       duplicationRatio(Alist),
+		DupRatioB:       duplicationRatio(Blist),
+		AShingles:       len(Aset),
+		BShingles:       len(Bset),
+		Intersection:    inter,
+		Union:           uni,
+	}
+}
+
+var wordReCompare = regexp.MustCompile(`\p{L}+|\p{N}+`)
+
+func normalize(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	return strings.TrimSpace(strings.Join(strings.Fields(s), " "))
+}
+func tokenize(s string) []string {
+	return wordReCompare.FindAllString(strings.ToLower(s), -1)
+}
+func shingleHashes(tokens []string, k int) ([]uint64, map[uint64]struct{}) {
+	if k <= 0 {
+		panic("k must be >= 1")
+	}
+	if len(tokens) < k {
+		return nil, map[uint64]struct{}{}
+	}
+	list := make([]uint64, 0, len(tokens)-k+1)
+	set := make(map[uint64]struct{}, cap(list))
+	for i := 0; i <= len(tokens)-k; i++ {
+		h := fnv64a(strings.Join(tokens[i:i+k], " "))
+		list = append(list, h)
+		set[h] = struct{}{}
+	}
+	return list, set
+}
+func fnv64a(s string) uint64 {
+	const (
+		offset64 = 1469598103934665603
+		prime64  = 1099511628211
+	)
+	var hash uint64 = offset64
+	for i := 0; i < len(s); i++ {
+		hash ^= uint64(s[i])
+		hash *= prime64
+	}
+	return hash
+}
+func intersectCount(a, b map[uint64]struct{}) int {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	if len(a) > len(b) {
+		a, b = b, a
+	}
+	c := 0
+	for h := range a {
+		if _, ok := b[h]; ok {
+			c++
+		}
+	}
+	return c
+}
+func duplicationRatio(list []uint64) float64 {
+	if len(list) == 0 {
+		return 0
+	}
+	seen := make(map[uint64]struct{}, len(list))
+	for _, h := range list {
+		seen[h] = struct{}{}
+	}
+	return float64(len(list)-len(seen)) / float64(len(list))
+}
+func sentenceCount(s string) int {
+	re := regexp.MustCompile(`[.!?]+|\n+`)
+	parts := re.Split(s, -1)
+	n := 0
+	for _, p := range parts {
+		if strings.TrimSpace(p) != "" {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/utils/compute_metrics_test.go
+++ b/internal/utils/compute_metrics_test.go
@@ -1,0 +1,337 @@
+package utils
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+func floatEqual(a, b float64) bool { return math.Abs(a-b) < 1e-6 }
+
+func TestComputeMetrics(t *testing.T) {
+	tests := []struct {
+		name     string
+		bodyA    string
+		bodyB    string
+		k        int
+		expected Metrics
+		desc     string
+	}{
+		{
+			name:  "identical_texts",
+			bodyA: "The quick brown fox jumps over the lazy dog",
+			bodyB: "The quick brown fox jumps over the lazy dog",
+			k:     5,
+			expected: Metrics{
+				ContainmentAinB: 1.0,
+				ContainmentBinA: 1.0,
+				Jaccard:         1.0,
+				NovelBminusA:    0.0,
+				DeltaTokens:     0,
+				DeltaChars:      0,
+				DeltaSent:       0,
+				DupRatioA:       0.0,
+				DupRatioB:       0.0,
+				AShingles:       5, // 9 tokens -> 9-5+1 = 5
+				BShingles:       5,
+				Intersection:    5,
+				Union:           5,
+			},
+			desc: "Identical texts should have perfect similarity metrics",
+		},
+		{
+			name:  "short_text_under_k_tokens",
+			bodyA: "Hello world",
+			bodyB: "Hello there",
+			k:     5,
+			expected: Metrics{
+				ContainmentAinB: 0.0,
+				ContainmentBinA: 0.0,
+				Jaccard:         0.0,
+				NovelBminusA:    1.0, // B is entirely novel vs A
+				DeltaTokens:     0,
+				DeltaChars:      0,
+				DeltaSent:       0,
+				DupRatioA:       0.0,
+				DupRatioB:       0.0,
+				AShingles:       1, // fixed behavior: 1 shingle per side when len(tokens) < k
+				BShingles:       1,
+				Intersection:    0,
+				Union:           2,
+			},
+			desc: "Short texts (<k) now produce one shingle each and proper set metrics",
+		},
+		{
+			name:  "short_text_under_k_tokens_identical",
+			bodyA: "Hello world",
+			bodyB: "hello   world!!",
+			k:     5,
+			expected: Metrics{
+				ContainmentAinB: 1.0,
+				ContainmentBinA: 1.0,
+				Jaccard:         1.0,
+				NovelBminusA:    0.0,
+				DeltaTokens:     0, // tokenization ignores case/punct for tokens
+				DeltaChars:      2, // "hello world!!" (13) - "Hello world" (11) = +2
+				DeltaSent:       1, // B has terminal "!!", A has none
+				DupRatioA:       0.0,
+				DupRatioB:       0.0,
+				AShingles:       1,
+				BShingles:       1,
+				Intersection:    1,
+				Union:           1,
+			},
+			desc: "Short identical texts (<k) yield a single matching shingle and perfect similarity",
+		},
+		{
+			name:  "empty_vs_non_empty",
+			bodyA: "",
+			bodyB: "Some content here",
+			k:     5,
+			expected: Metrics{
+				ContainmentAinB: 1.0, // empty is contained in anything
+				ContainmentBinA: 0.0,
+				Jaccard:         0.0,
+				NovelBminusA:    1.0, // all of B is novel
+				DeltaTokens:     3,
+				DeltaChars:      17,
+				DeltaSent:       0, // no terminal punctuation
+				DupRatioA:       0.0,
+				DupRatioB:       0.0,
+				AShingles:       0,
+				BShingles:       1, // fixed behavior for <k
+				Intersection:    0,
+				Union:           1,
+			},
+			desc: "Empty vs non-empty edge case with <k shingles",
+		},
+		{
+			name:  "both_empty",
+			bodyA: "",
+			bodyB: "",
+			k:     5,
+			expected: Metrics{
+				ContainmentAinB: 1.0,
+				ContainmentBinA: 1.0,
+				Jaccard:         1.0,
+				NovelBminusA:    0.0,
+				DeltaTokens:     0,
+				DeltaChars:      0,
+				DeltaSent:       0,
+				DupRatioA:       0.0,
+				DupRatioB:       0.0,
+				AShingles:       0,
+				BShingles:       0,
+				Intersection:    0,
+				Union:           0,
+			},
+			desc: "Both empty are identical",
+		},
+		{
+			name:  "duplication_detection",
+			bodyA: "word word word different",
+			bodyB: "word word word word different different",
+			k:     2,
+			expected: Metrics{
+				ContainmentAinB: 1.0,       // set-based: 2/2
+				ContainmentBinA: 2.0 / 3.0, // set-based: 2/3
+				Jaccard:         2.0 / 3.0, // 2 / (2+3-2)
+				NovelBminusA:    1.0 / 3.0, // (3-2)/3
+				DeltaTokens:     2,         // 6-4
+				DeltaChars:      15,        // with current normalize()
+				DeltaSent:       0,
+				DupRatioA:       1.0 / 3.0, // (3-2)/3 using list (bigrams: 3 total, 2 unique)
+				DupRatioB:       0.4,       // (5-3)/5
+				AShingles:       2,
+				BShingles:       3,
+				Intersection:    2,
+				Union:           3,
+			},
+			desc: "Duplication ratio and set overlaps line up on repeated n-grams",
+		},
+		{
+			name:  "normalization_test",
+			bodyA: "Text   with\r\nextra\twhitespace\r\n",
+			bodyB: "Text with extra whitespace",
+			k:     3,
+			expected: Metrics{
+				ContainmentAinB: 1.0,
+				ContainmentBinA: 1.0,
+				Jaccard:         1.0,
+				NovelBminusA:    0.0,
+				DeltaTokens:     0,
+				DeltaChars:      0, // strings.Fields collapse makes them identical
+				DeltaSent:       0,
+				DupRatioA:       0.0,
+				DupRatioB:       0.0,
+				AShingles:       2, // 4 tokens -> 4-3+1 = 2
+				BShingles:       2,
+				Intersection:    2,
+				Union:           2,
+			},
+			desc: "Whitespace normalization is consistent",
+		},
+	}
+
+	// NOTE: two tests above (sentence_counting_equalized, duplication_detection) include
+	//       more aggressive expectations. If you later change tokenization/normalization rules,
+	//       you may need to adjust their exact char deltas or shingle counts.
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ComputeMetrics(tt.bodyA, tt.bodyB, tt.k)
+
+			if !floatEqual(got.ContainmentAinB, tt.expected.ContainmentAinB) {
+				t.Errorf("ContainmentAinB: got %.10f, want %.10f (%s)", got.ContainmentAinB, tt.expected.ContainmentAinB, tt.desc)
+			}
+			if !floatEqual(got.ContainmentBinA, tt.expected.ContainmentBinA) {
+				t.Errorf("ContainmentBinA: got %.10f, want %.10f (%s)", got.ContainmentBinA, tt.expected.ContainmentBinA, tt.desc)
+			}
+			if !floatEqual(got.Jaccard, tt.expected.Jaccard) {
+				t.Errorf("Jaccard: got %.10f, want %.10f (%s)", got.Jaccard, tt.expected.Jaccard, tt.desc)
+			}
+			if !floatEqual(got.NovelBminusA, tt.expected.NovelBminusA) {
+				t.Errorf("NovelBminusA: got %.10f, want %.10f (%s)", got.NovelBminusA, tt.expected.NovelBminusA, tt.desc)
+			}
+
+			if got.DeltaTokens != tt.expected.DeltaTokens {
+				t.Errorf("DeltaTokens: got %d, want %d (%s)", got.DeltaTokens, tt.expected.DeltaTokens, tt.desc)
+			}
+			if got.DeltaChars != tt.expected.DeltaChars {
+				t.Errorf("DeltaChars: got %d, want %d (%s)", got.DeltaChars, tt.expected.DeltaChars, tt.desc)
+			}
+			if got.DeltaSent != tt.expected.DeltaSent {
+				t.Errorf("DeltaSent: got %d, want %d (%s)", got.DeltaSent, tt.expected.DeltaSent, tt.desc)
+			}
+
+			if got.DupRatioA != 0 || got.DupRatioB != 0 || tt.expected.DupRatioA != 0 || tt.expected.DupRatioB != 0 {
+				// compare with tolerance
+				if !floatEqual(got.DupRatioA, tt.expected.DupRatioA) {
+					t.Errorf("DupRatioA: got %.6f, want %.6f (%s)", got.DupRatioA, tt.expected.DupRatioA, tt.desc)
+				}
+				if !floatEqual(got.DupRatioB, tt.expected.DupRatioB) {
+					t.Errorf("DupRatioB: got %.6f, want %.6f (%s)", got.DupRatioB, tt.expected.DupRatioB, tt.desc)
+				}
+			}
+
+			if got.AShingles != tt.expected.AShingles {
+				t.Errorf("AShingles: got %d, want %d (%s)", got.AShingles, tt.expected.AShingles, tt.desc)
+			}
+			if got.BShingles != tt.expected.BShingles {
+				t.Errorf("BShingles: got %d, want %d (%s)", got.BShingles, tt.expected.BShingles, tt.desc)
+			}
+			if got.Intersection != tt.expected.Intersection {
+				t.Errorf("Intersection: got %d, want %d (%s)", got.Intersection, tt.expected.Intersection, tt.desc)
+			}
+			if got.Union != tt.expected.Union {
+				t.Errorf("Union: got %d, want %d (%s)", got.Union, tt.expected.Union, tt.desc)
+			}
+		})
+	}
+}
+
+func TestShingleGenerationFixed(t *testing.T) {
+	// explicit checks on list/set sizes for <k behavior
+	list, set := shingleHashes([]string{"hello", "world"}, 5)
+	if len(list) != 1 || len(set) != 1 {
+		t.Fatalf("<k shingle fix broken: want 1/1, got list=%d set=%d", len(list), len(set))
+	}
+	list2, set2 := shingleHashes([]string{}, 5)
+	if len(list2) != 0 || len(set2) != 0 {
+		t.Fatalf("empty tokens should yield empty shingles: got list=%d set=%d", len(list2), len(set2))
+	}
+}
+
+func TestContentExtractionScenarios(t *testing.T) {
+	type scen struct {
+		name       string
+		original   string
+		extracted  string
+		k          int
+		shouldPass bool
+		desc       string
+	}
+	isGoodExtraction := func(m Metrics) bool {
+		if m.ContainmentBinA < 0.95 {
+			return false
+		}
+		if m.NovelBminusA > 0.15 {
+			return false
+		}
+		if m.DeltaTokens > 0 {
+			return false
+		}
+		if m.DupRatioB > m.DupRatioA+1e-6 {
+			return false
+		}
+		return true
+	}
+	scenarios := []scen{
+		{
+			name: "good_extraction_removes_boilerplate",
+			original: `Main article content here with important details.
+
+Cookie banner: We use cookies to improve your experience.
+Subscribe to our newsletter!
+Privacy policy | Terms of service`,
+			extracted:  "Main article content here with important details.",
+			k:          3,
+			shouldPass: true,
+			desc:       "Keeps main content and removes boilerplate",
+		},
+		{
+			name:       "over_aggressive_extraction_loses_recall",
+			original:   "Important main content with details and context for understanding.",
+			extracted:  "Important main",
+			k:          3,
+			shouldPass: false,
+			desc:       "Drops too much content (low A→B containment)",
+		},
+		{
+			name: "noisy_additions",
+			original: `Core content paragraph that users care about.
+Another relevant paragraph with context.`,
+			extracted: `Core content paragraph that users care about.
+Another relevant paragraph with context.
+Sign up to our newsletter and accept all cookies!`,
+			k:          3,
+			shouldPass: false,
+			desc:       "Adds boilerplate/noise (high novel B−A; longer)",
+		},
+	}
+
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			m := ComputeMetrics(sc.original, sc.extracted, sc.k)
+			pass := isGoodExtraction(m)
+			if pass != sc.shouldPass {
+				t.Fatalf("%s\nHeuristic said pass=%v, want %v.\nMetrics: %+v", sc.desc, pass, sc.shouldPass, m)
+			}
+		})
+	}
+}
+
+func TestSentenceCountEqualized(t *testing.T) {
+	a := "First sentence. Second sentence! Third sentence?"
+	b := "First sentence...\n\nSecond sentence?!\nThird sentence!!!"
+
+	gotA := sentenceCount(a)
+	gotB := sentenceCount(b)
+
+	if gotA != 3 {
+		t.Fatalf("sentenceCount(A) = %d, want 3", gotA)
+	}
+	if gotB != 3 {
+		t.Fatalf("sentenceCount(B) = %d, want 3", gotB)
+	}
+}
+
+func BenchmarkComputeMetrics(b *testing.B) {
+	bodyA := strings.Repeat("This is a sample sentence for benchmarking purposes. ", 100)
+	bodyB := strings.Repeat("This is a modified sentence for benchmarking purposes. ", 95)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ComputeMetrics(bodyA, bodyB, 5)
+	}
+}

--- a/internal/utils/compute_metrics_test.go
+++ b/internal/utils/compute_metrics_test.go
@@ -326,6 +326,156 @@ func TestSentenceCountEqualized(t *testing.T) {
 	}
 }
 
+// -----------------------------
+// Bucket tests
+// -----------------------------
+// -----------------------------
+// Bucket tests
+// -----------------------------
+
+func TestBucket(t *testing.T) {
+	type tc struct {
+		name   string
+		m      Metrics
+		expect string
+		reason string
+	}
+	cases := []tc{
+		{
+			name: "much_worse_low_containment",
+			m: Metrics{
+				ContainmentAinB: 0.65, // below ThContainSlightWorseL (0.70)
+				Jaccard:         0.69, // also below 0.70 guard
+				DeltaTokens:     -5,
+				DeltaSent:       0,
+				DupRatioA:       0.00, DupRatioB: 0.05,
+				AShingles: 10, BShingles: 10,
+			},
+			expect: LMuchWorse, reason: "drop/empty/large_dup_increase",
+		},
+		{
+			name: "slightly_worse_partial_drop_by_containment_band",
+			m: Metrics{
+				ContainmentAinB: 0.85, // in [0.70, 0.90)
+				Jaccard:         0.90,
+				DeltaTokens:     -10, // not large enough to trigger much_worse
+				DeltaSent:       0,
+				DupRatioA:       0.02, DupRatioB: 0.03, // dupDelta = 0.01
+				AShingles: 10, BShingles: 10,
+			},
+			expect: LSlightWorse, reason: "partial_drop_or_dup_increase",
+		},
+		{
+			name: "slightly_worse_due_to_dup_increase",
+			m: Metrics{
+				ContainmentAinB: 0.93,
+				Jaccard:         0.93,
+				DeltaTokens:     0,
+				DeltaSent:       0,
+				DupRatioA:       0.02, DupRatioB: 0.07, // dupDelta = 0.05 -> slightly_worse
+				AShingles: 8, BShingles: 8,
+			},
+			expect: LSlightWorse, reason: "partial_drop_or_dup_increase",
+		},
+		{
+			name: "same_both_empty",
+			m: Metrics{
+				ContainmentAinB: 1.0, ContainmentBinA: 1.0, Jaccard: 1.0,
+				AShingles: 0, BShingles: 0,
+			},
+			expect: LSame, reason: "both_empty",
+		},
+		{
+			name: "same_sameish_high_similarity",
+			m: Metrics{
+				ContainmentAinB: 0.99, ContainmentBinA: 0.985, Jaccard: 0.981,
+				AShingles: 5, BShingles: 5,
+			},
+			expect: LSame, reason: "sameish",
+		},
+		{
+			name: "slightly_better_minor_gain_low_dup_by_tokens",
+			m: Metrics{
+				ContainmentAinB: 0.92, // >= 0.90
+				Jaccard:         0.92,
+				NovelBminusA:    0.10,                  // in [0.05, 0.15)
+				DupRatioA:       0.05, DupRatioB: 0.06, // dupDelta = 0.01 <= 0.03
+				DeltaTokens: 12, // >= 10
+				DeltaSent:   0,
+			},
+			expect: LSlightBetter, reason: "minor_gain_low_dup",
+		},
+		{
+			name: "slightly_better_minor_gain_low_dup_by_sentences",
+			m: Metrics{
+				ContainmentAinB: 0.91,
+				Jaccard:         0.91,
+				NovelBminusA:    0.06,
+				DupRatioA:       0.02, DupRatioB: 0.02, // dupDelta = 0.00
+				DeltaTokens: 3,
+				DeltaSent:   1, // >= 1
+			},
+			expect: LSlightBetter, reason: "minor_gain_low_dup",
+		},
+		{
+			name: "much_better_clear_gain_low_dup_by_tokens",
+			m: Metrics{
+				ContainmentAinB: 0.97, // >= 0.95
+				Jaccard:         0.97,
+				NovelBminusA:    0.20,                  // >= 0.15
+				DupRatioA:       0.10, DupRatioB: 0.11, // dupDelta = 0.01 <= 0.02
+				DeltaTokens: 60, // >= 50
+				DeltaSent:   0,
+			},
+			expect: LMuchBetter, reason: "clear_gain_low_dup",
+		},
+		{
+			name: "much_better_clear_gain_low_dup_by_sentences",
+			m: Metrics{
+				ContainmentAinB: 0.96,
+				Jaccard:         0.96,
+				NovelBminusA:    0.18,
+				DupRatioA:       0.03, DupRatioB: 0.03, // dupDelta = 0.00
+				DeltaTokens: 8,
+				DeltaSent:   2, // >= 2
+			},
+			expect: LMuchBetter, reason: "clear_gain_low_dup",
+		},
+		{
+			name: "much_worse_empty_B_after_A_nonempty",
+			m: Metrics{
+				ContainmentAinB: 0.0, Jaccard: 0.0,
+				AShingles: 5, BShingles: 0, // triggers worst case guard
+			},
+			expect: LMuchWorse, reason: "drop/empty/large_dup_increase",
+		},
+		{
+			name: "default_same_catch_all",
+			m: Metrics{
+				ContainmentAinB: 0.91, // not in slightly_worse band, below 0.98 sameish
+				ContainmentBinA: 0.91,
+				Jaccard:         0.91,
+				NovelBminusA:    0.02, // < 0.05 so not slightly_better
+				DupRatioA:       0.02, DupRatioB: 0.02,
+				DeltaTokens: 0,
+				DeltaSent:   0,
+				AShingles:   10, BShingles: 10,
+			},
+			expect: LSame, reason: "default_same",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, why := Bucket(tt.m)
+			if got != tt.expect || why != tt.reason {
+				t.Fatalf("Bucket(%+v) = (%s, %s), want (%s, %s)",
+					tt.m, got, why, tt.expect, tt.reason)
+			}
+		})
+	}
+}
+
 func BenchmarkComputeMetrics(b *testing.B) {
 	bodyA := strings.Repeat("This is a sample sentence for benchmarking purposes. ", 100)
 	bodyB := strings.Repeat("This is a modified sentence for benchmarking purposes. ", 95)


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1208205000179491/task/1211042695061839?focus=true

This PR adds comparison command to our fork of trafilatura, that enables running trafilatura extraction with control and variant, calculate metrics and analyze results (with bucketing analysis based on some defined thresholds).

It runs on an input directory with HTML files.

**This was from run where control=variant - so there's 36 sameish results:**

```
make compare IN=/mnt/efs/users/pkrayzel/index/data/go-trafilatura-tests/
Comparing control and variant of content extraction

./go-trafilatura compare \
  --in "/mnt/efs/users/pkrayzel/index/data/go-trafilatura-tests/" \
  --out "metrics.csv" \
  --k 5 \
  --concurrency 72 \
  --url-from canonical      \
   
2025-08-13 07:12 INF wrote metrics.csv
bucket summary: much_better=0 slightly_better=0 same=36 slightly_worse=0 much_worse=0 error=0 (n=36)
```

metrics.csv example:

```
url,file,containment_A_in_B,containment_B_in_A,jaccard,novel_B_minus_A,delta_tokens,delta_chars,delta_sentences,dup_ratio_A,dup_ratio_B,A_shingles,B_shingles,intersection,union,bucket,note
file:///mnt/efs/users/pkrayzel/index/data/go-trafilatura-tests/01_basic.html,/mnt/efs/users/pkrayzel/index/data/go-trafilatura-tests/01_basic.html,1,1,1,0,0,0,0,0,0,41,41,41,41,same,sameish
https://www.mlb.com/mets/,/mnt/efs/users/pkrayzel/index/data/go-trafilatura-tests/02_mlb_com_mets.html,1,1,1,0,0,0,0,0.272727,0.272727,272,272,272,272,same,sameish
https://www.imdb.com/title/tt36458116/,/mnt/efs/users/pkrayzel/index/data/go-trafilatura-tests/03_imdb_com_28_days_later.html,1,1,1,0,0,0,0,0.41,0.41,59,59,59,59,same,sameish
https://www.usopen.com/2025/scoring.html,/mnt/efs/users/pkrayzel/index/data/go-trafilatura-tests/04_usopen_com_2025_scoring.html,1,1,1,0,0,0,0,0.546099,0.546099,64,64,64,64,same,sameish
```

